### PR TITLE
Rewrite access control during 2fa phase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "symfony/http-foundation": "^4.4|^5.0",
         "symfony/http-kernel": "^4.4|^5.0",
         "symfony/property-access": "^4.4|^5.0",
-        "symfony/security-bundle": "^4.4|^5.0",
+        "symfony/security-bundle": "^4.4.1|^5.0",
         "symfony/twig-bundle": "^4.4|^5.0",
         "lcobucci/jwt": "^3.2",
         "spomky-labs/otphp": "^9.1|^10.0",

--- a/src/bundle/DependencyInjection/Compiler/AccessListenerCompilerPass.php
+++ b/src/bundle/DependencyInjection/Compiler/AccessListenerCompilerPass.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scheb\TwoFactorBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Injects a listener into the firewall to handle access control during the "2fa in progress" phase.
+ */
+class AccessListenerCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $taggedServices = $container->findTaggedServiceIds('scheb_two_factor.access_listener');
+        foreach ($taggedServices as $id => $attributes) {
+            if (!isset($attributes[0]['firewall'])) {
+                throw new InvalidArgumentException('Tag "scheb_two_factor.access_listener" requires attribute "firewall" to be set.');
+            }
+
+            $firewallContextId = 'security.firewall.map.context.'.$attributes[0]['firewall'];
+            $firewallContextDefinition = $container->getDefinition($firewallContextId);
+            $listenersIterator = $firewallContextDefinition->getArgument(0);
+            if (!($listenersIterator instanceof IteratorArgument)) {
+                throw new InvalidArgumentException(sprintf('Cannot inject access listener, argument 0 of "%s" must be instance of IteratorArgument.', $firewallContextId));
+            }
+
+            $listeners = $listenersIterator->getValues();
+            $listeners[] = new Reference($id);
+            $listenersIterator->setValues($listeners);
+        }
+    }
+}

--- a/src/bundle/DependencyInjection/Factory/Security/TwoFactorFactory.php
+++ b/src/bundle/DependencyInjection/Factory/Security/TwoFactorFactory.php
@@ -36,6 +36,7 @@ class TwoFactorFactory implements SecurityFactoryInterface
     public const FIREWALL_CONFIG_ID_PREFIX = 'security.firewall_config.two_factor.';
     public const PROVIDER_PREPARATION_LISTENER_ID_PREFIX = 'security.authentication.provider_preparation_listener.two_factor.';
     public const AUTHENTICATION_SUCCESS_EVENT_SUPPRESSOR_ID_PREFIX = 'security.authentication.authentication_success_event_suppressor.two_factor.';
+    public const KERNEL_EXCEPTION_LISTENER_ID_PREFIX = 'security.authentication.kernel_exception_listener.two_factor.';
 
     public const PROVIDER_DEFINITION_ID = 'scheb_two_factor.security.authentication.provider';
     public const LISTENER_DEFINITION_ID = 'scheb_two_factor.security.authentication.listener';
@@ -45,6 +46,7 @@ class TwoFactorFactory implements SecurityFactoryInterface
     public const FIREWALL_CONFIG_DEFINITION_ID = 'scheb_two_factor.security.firewall_config';
     public const PROVIDER_PREPARATION_LISTENER_DEFINITION_ID = 'scheb_two_factor.security.provider_preparation_listener';
     public const AUTHENTICATION_SUCCESS_EVENT_SUPPRESSOR_DEFINITION_ID = 'scheb_two_factor.security.authentication_success_event_suppressor';
+    public const KERNEL_EXCEPTION_LISTENER_DEFINITION_ID = 'scheb_two_factor.security.kernel_exception_listener';
 
     public function addConfiguration(NodeDefinition $node): void
     {
@@ -91,6 +93,7 @@ class TwoFactorFactory implements SecurityFactoryInterface
         $failureHandlerId = $this->createFailureHandler($container, $id, $config, $twoFactorFirewallConfigId);
         $authRequiredHandlerId = $this->createAuthenticationRequiredHandler($container, $id, $config, $twoFactorFirewallConfigId);
         $providerId = $this->createAuthenticationProvider($container, $id, $twoFactorFirewallConfigId);
+        $this->createKernelExceptionListener($container, $id, $authRequiredHandlerId);
         $this->createProviderPreparationListener($container, $id, $config);
         $this->createAuthenticationSuccessEventSuppressor($container, $id);
 
@@ -218,6 +221,16 @@ class TwoFactorFactory implements SecurityFactoryInterface
         $container
             ->setDefinition($firewallConfigId, new ChildDefinition(self::AUTHENTICATION_SUCCESS_EVENT_SUPPRESSOR_DEFINITION_ID))
             ->replaceArgument(0, $firewallName)
+            ->addTag('kernel.event_subscriber');
+    }
+
+    private function createKernelExceptionListener(ContainerBuilder $container, string $firewallName, string $authRequiredHandlerId): void
+    {
+        $firewallConfigId = self::KERNEL_EXCEPTION_LISTENER_ID_PREFIX.$firewallName;
+        $container
+            ->setDefinition($firewallConfigId, new ChildDefinition(self::KERNEL_EXCEPTION_LISTENER_DEFINITION_ID))
+            ->replaceArgument(0, $firewallName)
+            ->replaceArgument(2, new Reference($authRequiredHandlerId))
             ->addTag('kernel.event_subscriber');
     }
 

--- a/src/bundle/DependencyInjection/Factory/Security/TwoFactorFactory.php
+++ b/src/bundle/DependencyInjection/Factory/Security/TwoFactorFactory.php
@@ -37,6 +37,7 @@ class TwoFactorFactory implements SecurityFactoryInterface
     public const PROVIDER_PREPARATION_LISTENER_ID_PREFIX = 'security.authentication.provider_preparation_listener.two_factor.';
     public const AUTHENTICATION_SUCCESS_EVENT_SUPPRESSOR_ID_PREFIX = 'security.authentication.authentication_success_event_suppressor.two_factor.';
     public const KERNEL_EXCEPTION_LISTENER_ID_PREFIX = 'security.authentication.kernel_exception_listener.two_factor.';
+    public const KERNEL_ACCESS_LISTENER_ID_PREFIX = 'security.authentication.access_listener.two_factor.';
 
     public const PROVIDER_DEFINITION_ID = 'scheb_two_factor.security.authentication.provider';
     public const LISTENER_DEFINITION_ID = 'scheb_two_factor.security.authentication.listener';
@@ -47,6 +48,7 @@ class TwoFactorFactory implements SecurityFactoryInterface
     public const PROVIDER_PREPARATION_LISTENER_DEFINITION_ID = 'scheb_two_factor.security.provider_preparation_listener';
     public const AUTHENTICATION_SUCCESS_EVENT_SUPPRESSOR_DEFINITION_ID = 'scheb_two_factor.security.authentication_success_event_suppressor';
     public const KERNEL_EXCEPTION_LISTENER_DEFINITION_ID = 'scheb_two_factor.security.kernel_exception_listener';
+    public const KERNEL_ACCESS_LISTENER_DEFINITION_ID = 'scheb_two_factor.security.access_listener';
 
     public function addConfiguration(NodeDefinition $node): void
     {
@@ -94,6 +96,7 @@ class TwoFactorFactory implements SecurityFactoryInterface
         $authRequiredHandlerId = $this->createAuthenticationRequiredHandler($container, $id, $config, $twoFactorFirewallConfigId);
         $providerId = $this->createAuthenticationProvider($container, $id, $twoFactorFirewallConfigId);
         $this->createKernelExceptionListener($container, $id, $authRequiredHandlerId);
+        $this->createAccessListener($container, $id, $twoFactorFirewallConfigId);
         $this->createProviderPreparationListener($container, $id, $config);
         $this->createAuthenticationSuccessEventSuppressor($container, $id);
 
@@ -232,6 +235,17 @@ class TwoFactorFactory implements SecurityFactoryInterface
             ->replaceArgument(0, $firewallName)
             ->replaceArgument(2, new Reference($authRequiredHandlerId))
             ->addTag('kernel.event_subscriber');
+    }
+
+    private function createAccessListener(ContainerBuilder $container, string $firewallName, string $twoFactorFirewallConfigId): void
+    {
+        $firewallConfigId = self::KERNEL_ACCESS_LISTENER_ID_PREFIX.$firewallName;
+        $container
+            ->setDefinition($firewallConfigId, new ChildDefinition(self::KERNEL_ACCESS_LISTENER_DEFINITION_ID))
+            ->replaceArgument(0, new Reference($twoFactorFirewallConfigId))
+            // The SecurityFactory doesn't have access to the service definitions from the security bundle. Therefore we
+            // tag the definition so we can find it in a compiler pass inject it into the firewall context.
+            ->addTag('scheb_two_factor.access_listener', ['firewall' => $firewallName]);
     }
 
     public function getPosition(): string

--- a/src/bundle/Resources/config/security.xml
+++ b/src/bundle/Resources/config/security.xml
@@ -47,7 +47,7 @@
 			<tag name="monolog.logger" channel="security" />
 		</service>
 
-		<service id="scheb_two_factor.security.rememberme_services_decorator" class="\Scheb\TwoFactorBundle\Security\Authentication\RememberMe\RememberMeServicesDecorator" abstract="true">
+		<service id="scheb_two_factor.security.rememberme_services_decorator" class="Scheb\TwoFactorBundle\Security\Authentication\RememberMe\RememberMeServicesDecorator" abstract="true">
 			<argument /> <!-- Decorated remember-me services instance -->
 		</service>
 

--- a/src/bundle/Resources/config/security.xml
+++ b/src/bundle/Resources/config/security.xml
@@ -68,6 +68,15 @@
 			<!-- <tag name="kernel.event_subscriber" /> -->
 		</service>
 
+		<service id="scheb_two_factor.security.kernel_exception_listener" class="Scheb\TwoFactorBundle\Security\Http\Firewall\ExceptionListener" abstract="true">
+			<argument type="string" /> <!-- Firewall name -->
+			<argument type="service" id="security.token_storage"/>
+			<argument /> <!-- Authentication required handler -->
+			<argument type="service" id="event_dispatcher" />
+			<!-- This tag must be added when the child definition is created -->
+			<!-- <tag name="kernel.event_subscriber" /> -->
+		</service>
+
 		<service id="scheb_two_factor.security.authentication.success_handler" class="Scheb\TwoFactorBundle\Security\Http\Authentication\DefaultAuthenticationSuccessHandler" abstract="true">
 			<argument type="service" id="security.http_utils" />
 			<argument type="string" /> <!-- Firewall name -->

--- a/src/bundle/Resources/config/security.xml
+++ b/src/bundle/Resources/config/security.xml
@@ -76,6 +76,13 @@
 			<!-- <tag name="kernel.event_subscriber" /> -->
 		</service>
 
+		<service id="scheb_two_factor.security.access_listener" class="Scheb\TwoFactorBundle\Security\Http\Firewall\TwoFactorAccessListener" abstract="true">
+			<argument /> <!-- Two-factor firewall config -->
+			<argument type="service" id="security.token_storage"/>
+			<argument type="service" id="scheb_two_factor.security.access.access_decider"/>
+			<argument type="service" id="event_dispatcher" />
+		</service>
+
 		<service id="scheb_two_factor.security.authentication.success_handler" class="Scheb\TwoFactorBundle\Security\Http\Authentication\DefaultAuthenticationSuccessHandler" abstract="true">
 			<argument type="service" id="security.http_utils" />
 			<argument type="string" /> <!-- Firewall name -->

--- a/src/bundle/Resources/config/security.xml
+++ b/src/bundle/Resources/config/security.xml
@@ -40,7 +40,6 @@
 			<argument /> <!-- Authentication required handler -->
 			<argument /> <!-- CSRF token manager -->
 			<argument type="service" id="scheb_two_factor.trusted_device_manager" on-invalid="null" />
-			<argument type="service" id="scheb_two_factor.security.access.access_decider" />
 			<argument type="service" id="event_dispatcher" />
 			<argument type="service" id="scheb_two_factor.token_factory" />
 			<argument type="service" id="logger" on-invalid="null" />

--- a/src/bundle/SchebTwoFactorBundle.php
+++ b/src/bundle/SchebTwoFactorBundle.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Scheb\TwoFactorBundle;
 
+use Scheb\TwoFactorBundle\DependencyInjection\Compiler\AccessListenerCompilerPass;
 use Scheb\TwoFactorBundle\DependencyInjection\Compiler\AuthenticationProviderDecoratorCompilerPass;
 use Scheb\TwoFactorBundle\DependencyInjection\Compiler\MailerCompilerPass;
 use Scheb\TwoFactorBundle\DependencyInjection\Compiler\RememberMeServicesDecoratorCompilerPass;
@@ -22,6 +23,7 @@ class SchebTwoFactorBundle extends Bundle
 
         $container->addCompilerPass(new AuthenticationProviderDecoratorCompilerPass());
         $container->addCompilerPass(new RememberMeServicesDecoratorCompilerPass());
+        $container->addCompilerPass(new AccessListenerCompilerPass());
         $container->addCompilerPass(new TwoFactorProviderCompilerPass());
         $container->addCompilerPass(new TwoFactorFirewallConfigCompilerPass());
         $container->addCompilerPass(new MailerCompilerPass());

--- a/src/bundle/Security/Http/Firewall/ExceptionListener.php
+++ b/src/bundle/Security/Http/Firewall/ExceptionListener.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scheb\TwoFactorBundle\Security\Http\Firewall;
+
+use Scheb\TwoFactorBundle\Security\Authentication\Token\TwoFactorTokenInterface;
+use Scheb\TwoFactorBundle\Security\Http\Authentication\AuthenticationRequiredHandlerInterface;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorAuthenticationEvent;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorAuthenticationEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+class ExceptionListener implements EventSubscriberInterface
+{
+    // Just before the firewall's Symfony\Component\Security\Http\Firewall\ExceptionListener
+    private const LISTENER_PRIORITY = 2;
+
+    /**
+     * @var string
+     */
+    private $firewallName;
+
+    /**
+     * @var TokenStorageInterface
+     */
+    private $tokenStorage;
+
+    /**
+     * @var AuthenticationRequiredHandlerInterface
+     */
+    private $authenticationRequiredHandler;
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    public function __construct(
+        string $firewallName,
+        TokenStorageInterface $tokenStorage,
+        AuthenticationRequiredHandlerInterface $authenticationRequiredHandler,
+        EventDispatcherInterface $eventDispatcher
+    ) {
+        $this->firewallName = $firewallName;
+        $this->tokenStorage = $tokenStorage;
+        $this->authenticationRequiredHandler = $authenticationRequiredHandler;
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    public function onKernelException(ExceptionEvent $event): void
+    {
+        $exception = $event->getThrowable();
+        do {
+            if ($exception instanceof AccessDeniedException) {
+                $this->handleAccessDeniedException($event);
+
+                return;
+            }
+        } while (null !== $exception = $exception->getPrevious());
+    }
+
+    private function handleAccessDeniedException(ExceptionEvent $exceptionEvent): void
+    {
+        $token = $this->tokenStorage->getToken();
+        if (!($token instanceof TwoFactorTokenInterface && $token->getProviderKey() === $this->firewallName)) {
+            return;
+        }
+
+        /** @var TwoFactorTokenInterface $token */
+        $request = $exceptionEvent->getRequest();
+
+        $event = new TwoFactorAuthenticationEvent($request, $token);
+        $this->eventDispatcher->dispatch($event, TwoFactorAuthenticationEvents::REQUIRE);
+
+        $response = $this->authenticationRequiredHandler->onAuthenticationRequired($request, $token);
+        $exceptionEvent->setResponse($response);
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::EXCEPTION => ['onKernelException', self::LISTENER_PRIORITY],
+        ];
+    }
+}

--- a/src/bundle/Security/Http/Firewall/TwoFactorAccessListener.php
+++ b/src/bundle/Security/Http/Firewall/TwoFactorAccessListener.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scheb\TwoFactorBundle\Security\Http\Firewall;
+
+use Scheb\TwoFactorBundle\Security\Authentication\Token\TwoFactorTokenInterface;
+use Scheb\TwoFactorBundle\Security\Authorization\TwoFactorAccessDecider;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorAuthenticationEvent;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorAuthenticationEvents;
+use Scheb\TwoFactorBundle\Security\TwoFactor\TwoFactorFirewallConfig;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Component\Security\Http\Firewall\AbstractListener;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * Handles access control in the "2fa in progress" phase.
+ */
+class TwoFactorAccessListener extends AbstractListener
+{
+    /**
+     * @var TwoFactorFirewallConfig
+     */
+    private $twoFactorFirewallConfig;
+
+    /**
+     * @var TokenStorageInterface
+     */
+    private $tokenStorage;
+
+    /**
+     * @var TwoFactorAccessDecider
+     */
+    private $twoFactorAccessDecider;
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    public function __construct(
+        TwoFactorFirewallConfig $twoFactorFirewallConfig,
+        TokenStorageInterface $tokenStorage,
+        TwoFactorAccessDecider $twoFactorAccessDecider,
+        EventDispatcherInterface $eventDispatcher
+    ) {
+        $this->twoFactorFirewallConfig = $twoFactorFirewallConfig;
+        $this->tokenStorage = $tokenStorage;
+        $this->twoFactorAccessDecider = $twoFactorAccessDecider;
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    public function supports(Request $request): ?bool
+    {
+        $token = $this->tokenStorage->getToken();
+
+        // No need to check for firewall name here, the listener is bound to the firewall context
+        return $token instanceof TwoFactorTokenInterface;
+    }
+
+    public function authenticate(RequestEvent $requestEvent): void
+    {
+        /** @var TwoFactorTokenInterface $token */
+        $token = $this->tokenStorage->getToken();
+        $request = $requestEvent->getRequest();
+        if ($this->twoFactorFirewallConfig->isCheckPathRequest($request)) {
+            return;
+        }
+
+        if ($this->twoFactorFirewallConfig->isAuthFormRequest($request)) {
+            $event = new TwoFactorAuthenticationEvent($request, $token);
+            $this->eventDispatcher->dispatch($event, TwoFactorAuthenticationEvents::FORM);
+
+            return;
+        }
+
+        if (!$this->twoFactorAccessDecider->isAccessible($request, $token)) {
+            $exception = new AccessDeniedException('User is in a two-factor authentication process.');
+            $exception->setSubject($request);
+
+            throw $exception;
+        }
+    }
+}

--- a/src/bundle/composer.json
+++ b/src/bundle/composer.json
@@ -20,7 +20,7 @@
         "symfony/http-foundation": "^4.4|^5.0",
         "symfony/http-kernel": "^4.4|^5.0",
         "symfony/property-access": "^4.4|^5.0",
-        "symfony/security-bundle": "^4.4|^5.0",
+        "symfony/security-bundle": "^4.4.1|^5.0",
         "symfony/twig-bundle": "^4.4|^5.0"
     },
     "autoload": {

--- a/tests/DependencyInjection/Compiler/AccessListenerCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AccessListenerCompilerPassTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scheb\TwoFactorBundle\Tests\DependencyInjection\Compiler;
+
+use Scheb\TwoFactorBundle\DependencyInjection\Compiler\AccessListenerCompilerPass;
+use Scheb\TwoFactorBundle\Tests\TestCase;
+use Symfony\Bundle\SecurityBundle\Security\FirewallContext;
+use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Reference;
+
+class AccessListenerCompilerPassTest extends TestCase
+{
+    /**
+     * @var AccessListenerCompilerPass
+     */
+    private $compilerPass;
+
+    /**
+     * @var ContainerBuilder
+     */
+    private $container;
+
+    /**
+     * @var Definition
+     */
+    private $firewallContextDefinition;
+
+    protected function setUp(): void
+    {
+        $this->container = new ContainerBuilder();
+        $this->compilerPass = new AccessListenerCompilerPass();
+
+        $this->firewallContextDefinition = new Definition(FirewallContext::class);
+        $this->container->setDefinition('security.firewall.map.context.firewallName', $this->firewallContextDefinition);
+    }
+
+    private function stubTaggedContainerService(array $taggedServices): void
+    {
+        foreach ($taggedServices as $id => $tags) {
+            $definition = $this->container->register($id);
+
+            foreach ($tags as $attributes) {
+                $definition->addTag('scheb_two_factor.access_listener', $attributes);
+            }
+        }
+    }
+
+    private function stubFirewallContextListeners($listenersArg): void
+    {
+        $this->firewallContextDefinition->setArgument(0, $listenersArg);
+    }
+
+    private function assertFirewallContextListeners(IteratorArgument $expected): void
+    {
+        $listenersArgument = $this->firewallContextDefinition->getArgument(0);
+        $this->assertEquals($expected, $listenersArgument);
+    }
+
+    /**
+     * @test
+     */
+    public function process_missingAlias_throwException(): void
+    {
+        $taggedServices = [
+            'serviceId' => [
+                0 => [],
+            ],
+        ];
+        $this->stubTaggedContainerService($taggedServices);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Tag "scheb_two_factor.access_listener" requires attribute "firewall" to be set');
+        $this->compilerPass->process($this->container);
+    }
+
+    /**
+     * @test
+     */
+    public function process_invalidListenersArgument_throwException(): void
+    {
+        $taggedServices = [
+            'serviceId' => [
+                0 => ['firewall' => 'firewallName'],
+            ],
+        ];
+        $this->stubTaggedContainerService($taggedServices);
+        $this->stubFirewallContextListeners([]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot inject access listener');
+        $this->compilerPass->process($this->container);
+    }
+
+    /**
+     * @test
+     */
+    public function process_requirementsFulfilled_addAccessListener(): void
+    {
+        $taggedServices = [
+            'serviceId' => [
+                0 => ['firewall' => 'firewallName'],
+            ],
+        ];
+
+        $this->stubTaggedContainerService($taggedServices);
+        $this->stubFirewallContextListeners(new IteratorArgument([
+            new Reference('firewallListener1'),
+            new Reference('firewallListener2'),
+        ]));
+
+        $this->compilerPass->process($this->container);
+
+        $this->assertFirewallContextListeners(new IteratorArgument([
+            new Reference('firewallListener1'),
+            new Reference('firewallListener2'),
+            new Reference('serviceId'),
+        ]));
+    }
+}

--- a/tests/DependencyInjection/Factory/Security/TwoFactorFactoryTest.php
+++ b/tests/DependencyInjection/Factory/Security/TwoFactorFactoryTest.php
@@ -260,8 +260,13 @@ EOF;
         ]);
 
         $this->assertFalse($this->container->hasDefinition('security.authentication.authentication_required_handler.two_factor.firewallName'));
+
+        // Assert the custom handler is used
         $definition = $this->container->getDefinition('security.authentication.listener.two_factor.firewallName');
         $this->assertEquals(new Reference('my_authentication_required_handler'), $definition->getArgument(5));
+
+        $definition = $this->container->getDefinition('security.authentication.kernel_exception_listener.two_factor.firewallName');
+        $this->assertEquals(new Reference('my_authentication_required_handler'), $definition->getArgument(2));
     }
 
     /**
@@ -332,6 +337,19 @@ EOF;
         $this->assertEquals(self::FIREWALL_NAME, $definition->getArgument(0));
         $tag = $definition->getTag('kernel.event_subscriber');
         $this->assertCount(1, $tag, 'Must have the "kernel.event_subscriber" tag assigned');
+    }
+
+    /**
+     * @test
+     */
+    public function create_createForFirewall_createExceptionListener(): void
+    {
+        $this->callCreateFirewall();
+
+        $this->assertTrue($this->container->hasDefinition('security.authentication.kernel_exception_listener.two_factor.firewallName'));
+        $definition = $this->container->getDefinition('security.authentication.kernel_exception_listener.two_factor.firewallName');
+        $this->assertEquals('firewallName', $definition->getArgument(0));
+        $this->assertEquals(new Reference('security.authentication.authentication_required_handler.two_factor.firewallName'), $definition->getArgument(2));
     }
 }
 

--- a/tests/DependencyInjection/Factory/Security/TwoFactorFactoryTest.php
+++ b/tests/DependencyInjection/Factory/Security/TwoFactorFactoryTest.php
@@ -351,6 +351,21 @@ EOF;
         $this->assertEquals('firewallName', $definition->getArgument(0));
         $this->assertEquals(new Reference('security.authentication.authentication_required_handler.two_factor.firewallName'), $definition->getArgument(2));
     }
+
+    /**
+     * @test
+     */
+    public function create_createForFirewall_createAccessListener(): void
+    {
+        $this->callCreateFirewall();
+
+        $this->assertTrue($this->container->hasDefinition('security.authentication.access_listener.two_factor.firewallName'));
+        $definition = $this->container->getDefinition('security.authentication.access_listener.two_factor.firewallName');
+        $this->assertEquals(new Reference('security.firewall_config.two_factor.firewallName'), $definition->getArgument(0));
+        $this->assertTrue($definition->hasTag('scheb_two_factor.access_listener'));
+        $tag = $definition->getTag('scheb_two_factor.access_listener');
+        $this->assertEquals(['firewall' => 'firewallName'], $tag[0]);
+    }
 }
 
 // Helper class to process config

--- a/tests/SchebTwoFactorBundleTest.php
+++ b/tests/SchebTwoFactorBundleTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Scheb\TwoFactorBundle\Tests;
 
+use Scheb\TwoFactorBundle\DependencyInjection\Compiler\AccessListenerCompilerPass;
 use Scheb\TwoFactorBundle\DependencyInjection\Compiler\AuthenticationProviderDecoratorCompilerPass;
 use Scheb\TwoFactorBundle\DependencyInjection\Compiler\MailerCompilerPass;
 use Scheb\TwoFactorBundle\DependencyInjection\Compiler\RememberMeServicesDecoratorCompilerPass;
@@ -25,11 +26,12 @@ class SchebTwoFactorBundleTest extends TestCase
 
         //Expect compiler pass to be added
         $containerBuilder
-            ->expects($this->exactly(5))
+            ->expects($this->exactly(6))
             ->method('addCompilerPass')
             ->with($this->logicalOr(
                 $this->isInstanceOf(AuthenticationProviderDecoratorCompilerPass::class),
                 $this->isInstanceOf(RememberMeServicesDecoratorCompilerPass::class),
+                $this->isInstanceOf(AccessListenerCompilerPass::class),
                 $this->isInstanceOf(TwoFactorProviderCompilerPass::class),
                 $this->isInstanceOf(TwoFactorFirewallConfigCompilerPass::class),
                 $this->isInstanceOf(MailerCompilerPass::class)

--- a/tests/Security/Http/Firewall/ExceptionListenerTest.php
+++ b/tests/Security/Http/Firewall/ExceptionListenerTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scheb\TwoFactorBundle\Tests\Security\Http\Firewall;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use Scheb\TwoFactorBundle\Security\Authentication\Token\TwoFactorTokenInterface;
+use Scheb\TwoFactorBundle\Security\Http\Authentication\AuthenticationRequiredHandlerInterface;
+use Scheb\TwoFactorBundle\Security\Http\Firewall\ExceptionListener;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorAuthenticationEvent;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorAuthenticationEvents;
+use Scheb\TwoFactorBundle\Tests\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+class ExceptionListenerTest extends TestCase
+{
+    private const FIREWALL_NAME = 'firewallName';
+
+    /**
+     * @var MockObject|TokenStorageInterface
+     */
+    private $tokenStorage;
+
+    /**
+     * @var MockObject|AuthenticationRequiredHandlerInterface
+     */
+    private $authenticationRequiredHandler;
+
+    /**
+     * @var MockObject|EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    /**
+     * @var MockObject|Request
+     */
+    private $request;
+
+    /**
+     * @var MockObject|Response
+     */
+    private $response;
+
+    /**
+     * @var ExceptionListener
+     */
+    private $listener;
+
+    protected function setUp(): void
+    {
+        $this->tokenStorage = $this->createMock(TokenStorageInterface::class);
+        $this->authenticationRequiredHandler = $this->createMock(AuthenticationRequiredHandlerInterface::class);
+        $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $this->request = $this->createMock(Request::class);
+        $this->response = $this->createMock(Response::class);
+
+        $this->listener = new ExceptionListener(
+            self::FIREWALL_NAME,
+            $this->tokenStorage,
+            $this->authenticationRequiredHandler,
+            $this->eventDispatcher
+        );
+    }
+
+    private function stubTokenStorageHasToken(TokenInterface $token): void
+    {
+        $this->tokenStorage
+            ->expects($this->any())
+            ->method('getToken')
+            ->willReturn($token);
+    }
+
+    private function expectAuthenticationRequireEvent(): void
+    {
+        $this->eventDispatcher
+            ->expects($this->any())
+            ->method('dispatch')
+            ->with($this->isInstanceOf(TwoFactorAuthenticationEvent::class), TwoFactorAuthenticationEvents::REQUIRE);
+    }
+
+    private function expectAuthenticationRequiredHandlerCreateResponse(TokenInterface $token, Response $response): void
+    {
+        $this->authenticationRequiredHandler
+            ->expects($this->any())
+            ->method('onAuthenticationRequired')
+            ->with($this->identicalTo($this->request), $token)
+            ->willReturn($response);
+    }
+
+    /**
+     * @return MockObject|TwoFactorTokenInterface
+     */
+    private function createTwoFactorToken(string $firewallName): MockObject
+    {
+        $token = $this->createMock(TwoFactorTokenInterface::class);
+        $token
+            ->expects($this->any())
+            ->method('getProviderKey')
+            ->willReturn($firewallName);
+
+        return $token;
+    }
+
+    private function createExceptionEvent(\Throwable $exception): ExceptionEvent
+    {
+        return new ExceptionEvent(
+            $this->createMock(HttpKernelInterface::class),
+            $this->request,
+            HttpKernelInterface::MASTER_REQUEST,
+            $exception
+        );
+    }
+
+    private function assertNotHasResponse(ExceptionEvent $event): void
+    {
+        $this->assertNull($event->getResponse());
+    }
+
+    private function assertHasResponse(ExceptionEvent $event, Response $response): void
+    {
+        $this->assertSame($response, $event->getResponse());
+    }
+
+    /**
+     * @test
+     */
+    public function onKernelException_notAccessDeniedException_doNothing(): void
+    {
+        $this->stubTokenStorageHasToken($this->createTwoFactorToken(self::FIREWALL_NAME));
+        $event = $this->createExceptionEvent(new \InvalidArgumentException());
+
+        $this->listener->onKernelException($event);
+        $this->assertNotHasResponse($event);
+    }
+
+    /**
+     * @test
+     */
+    public function onKernelException_notTwoFactorToken_doNothing(): void
+    {
+        $this->stubTokenStorageHasToken($this->createMock(TokenInterface::class));
+        $event = $this->createExceptionEvent(new AccessDeniedException());
+
+        $this->listener->onKernelException($event);
+        $this->assertNotHasResponse($event);
+    }
+
+    /**
+     * @test
+     */
+    public function onKernelException_differentFirewall_doNothing(): void
+    {
+        $this->stubTokenStorageHasToken($this->createTwoFactorToken('differentFirewallName'));
+        $event = $this->createExceptionEvent(new AccessDeniedException());
+
+        $this->listener->onKernelException($event);
+        $this->assertNotHasResponse($event);
+    }
+
+    /**
+     * @test
+     * @dataProvider provideExceptions
+     */
+    public function onKernelException_allConditionsFulfilled_displayRequireEventSetResponse(\Throwable $exception): void
+    {
+        $token = $this->createTwoFactorToken(self::FIREWALL_NAME);
+        $this->stubTokenStorageHasToken($token);
+        $event = $this->createExceptionEvent($exception);
+
+        $this->expectAuthenticationRequiredHandlerCreateResponse($token, $this->response);
+        $this->expectAuthenticationRequireEvent();
+
+        $this->listener->onKernelException($event);
+        $this->assertHasResponse($event, $this->response);
+    }
+
+    public function provideExceptions(): array
+    {
+        return [
+            'AccessDeniedException' => [new AccessDeniedException()],
+            'nested AccessDeniedException' => [new \Exception('msg', 0, new AccessDeniedException())],
+        ];
+    }
+}

--- a/tests/Security/Http/Firewall/TwoFactorAccessListenerTest.php
+++ b/tests/Security/Http/Firewall/TwoFactorAccessListenerTest.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scheb\TwoFactorBundle\Tests\Security\Http\Firewall;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use Scheb\TwoFactorBundle\Security\Authentication\Token\TwoFactorTokenInterface;
+use Scheb\TwoFactorBundle\Security\Authorization\TwoFactorAccessDecider;
+use Scheb\TwoFactorBundle\Security\Http\Firewall\TwoFactorAccessListener;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorAuthenticationEvent;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorAuthenticationEvents;
+use Scheb\TwoFactorBundle\Security\TwoFactor\TwoFactorFirewallConfig;
+use Scheb\TwoFactorBundle\Tests\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+class TwoFactorAccessListenerTest extends TestCase
+{
+    /**
+     * @var MockObject|TwoFactorFirewallConfig
+     */
+    private $twoFactorFirewallConfig;
+
+    /**
+     * @var MockObject|TokenStorageInterface
+     */
+    private $tokenStorage;
+
+    /**
+     * @var MockObject|TwoFactorAccessDecider
+     */
+    private $twoFactorAccessDecider;
+
+    /**
+     * @var MockObject|EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    /**
+     * @var TwoFactorAccessListener
+     */
+    private $accessListener;
+
+    /**
+     * @var MockObject|Request
+     */
+    private $request;
+
+    protected function setUp(): void
+    {
+        $this->twoFactorFirewallConfig = $this->createMock(TwoFactorFirewallConfig::class);
+        $this->tokenStorage = $this->createMock(TokenStorageInterface::class);
+        $this->twoFactorAccessDecider = $this->createMock(TwoFactorAccessDecider::class);
+        $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $this->request = $this->createMock(Request::class);
+
+        $this->accessListener = new TwoFactorAccessListener(
+            $this->twoFactorFirewallConfig,
+            $this->tokenStorage,
+            $this->twoFactorAccessDecider,
+            $this->eventDispatcher
+        );
+    }
+
+    /**
+     * @return MockObject|TwoFactorTokenInterface
+     */
+    private function createTwoFactorToken(): MockObject
+    {
+        return $this->createMock(TwoFactorTokenInterface::class);
+    }
+
+    private function createRequestEvent(): RequestEvent
+    {
+        $requestEvent = $this->createMock(RequestEvent::class);
+        $requestEvent
+            ->expects($this->any())
+            ->method('getRequest')
+            ->willReturn($this->request);
+
+        return $requestEvent;
+    }
+
+    private function stubTokenStorageHasToken(TokenInterface $token): void
+    {
+        $this->tokenStorage
+            ->expects($this->any())
+            ->method('getToken')
+            ->willReturn($token);
+    }
+
+    private function stubRequestIsCheckPath(bool $isCheckPath): void
+    {
+        $this->twoFactorFirewallConfig
+            ->expects($this->any())
+            ->method('isCheckPathRequest')
+            ->with($this->request)
+            ->willReturn($isCheckPath);
+    }
+
+    private function stubRequestIsAuthPath(bool $isCheckPath): void
+    {
+        $this->twoFactorFirewallConfig
+            ->expects($this->any())
+            ->method('isAuthFormRequest')
+            ->with($this->request)
+            ->willReturn($isCheckPath);
+    }
+
+    /**
+     * @test
+     */
+    public function supports_notTwoFactorToken_returnFalse(): void
+    {
+        $this->stubTokenStorageHasToken($this->createMock(TokenInterface::class));
+        $this->assertFalse($this->accessListener->supports($this->request));
+    }
+
+    /**
+     * @test
+     */
+    public function supports_isTwoFactorToken_returnTrue(): void
+    {
+        $this->stubTokenStorageHasToken($this->createTwoFactorToken());
+        $this->assertTrue($this->accessListener->supports($this->request));
+    }
+
+    /**
+     * @test
+     */
+    public function authenticate_isCheckPathRequest_doNothing(): void
+    {
+        $this->stubTokenStorageHasToken($this->createTwoFactorToken());
+        $this->stubRequestIsCheckPath(true);
+        $this->stubRequestIsAuthPath(false);
+
+        $this->twoFactorAccessDecider
+            ->expects($this->never())
+            ->method($this->anything());
+
+        $this->accessListener->authenticate($this->createRequestEvent());
+    }
+
+    /**
+     * @test
+     */
+    public function authenticate_isAuthFormRequest_dispatchEvent(): void
+    {
+        $this->stubTokenStorageHasToken($this->createTwoFactorToken());
+        $this->stubRequestIsCheckPath(false);
+        $this->stubRequestIsAuthPath(true);
+
+        $this->eventDispatcher
+            ->expects($this->any())
+            ->method('dispatch')
+            ->with($this->isInstanceOf(TwoFactorAuthenticationEvent::class), TwoFactorAuthenticationEvents::FORM);
+
+        $this->twoFactorAccessDecider
+            ->expects($this->never())
+            ->method($this->anything());
+
+        $this->accessListener->authenticate($this->createRequestEvent());
+    }
+
+    /**
+     * @test
+     */
+    public function authenticate_noSpecialPath_checkIfAccessible(): void
+    {
+        $token = $this->createTwoFactorToken();
+        $this->stubTokenStorageHasToken($token);
+        $this->stubRequestIsCheckPath(false);
+        $this->stubRequestIsAuthPath(false);
+
+        $this->twoFactorAccessDecider
+            ->expects($this->once())
+            ->method('isAccessible')
+            ->with($this->request, $token)
+            ->willReturn(true);
+
+        $this->accessListener->authenticate($this->createRequestEvent());
+    }
+
+    /**
+     * @test
+     */
+    public function authenticate_isAccessDenied_throwAccessDeniedException(): void
+    {
+        $token = $this->createTwoFactorToken();
+        $this->stubTokenStorageHasToken($token);
+        $this->stubRequestIsCheckPath(false);
+        $this->stubRequestIsAuthPath(false);
+
+        $this->twoFactorAccessDecider
+            ->expects($this->once())
+            ->method('isAccessible')
+            ->with($this->request, $token)
+            ->willReturn(false);
+
+        $this->expectException(AccessDeniedException::class);
+        $this->expectExceptionMessage('User is in a two-factor authentication process');
+
+        $this->accessListener->authenticate($this->createRequestEvent());
+    }
+}

--- a/tests/Security/Http/Firewall/TwoFactorListenerTest.php
+++ b/tests/Security/Http/Firewall/TwoFactorListenerTest.php
@@ -200,7 +200,7 @@ class TwoFactorListenerTest extends TestCase
         return $twoFactorToken;
     }
 
-    private function stubTokenManagerHasToken(TokenInterface $token): void
+    private function stubTokenStorageHasToken(TokenInterface $token): void
     {
         $this->tokenStorage
             ->expects($this->any())
@@ -317,7 +317,7 @@ class TwoFactorListenerTest extends TestCase
      */
     public function handle_noTwoFactorToken_doNothing(): void
     {
-        $this->stubTokenManagerHasToken($this->createMock(TokenInterface::class));
+        $this->stubTokenStorageHasToken($this->createMock(TokenInterface::class));
         $this->stubRequestIsCheckPath(true);
 
         $this->assertNoResponseSet();
@@ -330,7 +330,7 @@ class TwoFactorListenerTest extends TestCase
      */
     public function handle_differentFirewallName_doNothing(): void
     {
-        $this->stubTokenManagerHasToken($this->createTwoFactorToken('otherFirewallName'));
+        $this->stubTokenStorageHasToken($this->createTwoFactorToken('otherFirewallName'));
         $this->stubRequestIsCheckPath(true);
 
         $this->assertNoResponseSet();
@@ -343,7 +343,7 @@ class TwoFactorListenerTest extends TestCase
      */
     public function handle_notCheckPath_doNothing(): void
     {
-        $this->stubTokenManagerHasToken($this->createTwoFactorToken());
+        $this->stubTokenStorageHasToken($this->createTwoFactorToken());
         $this->stubRequestIsCheckPath(false);
 
         $this->assertNoResponseSet();
@@ -358,7 +358,7 @@ class TwoFactorListenerTest extends TestCase
     {
         $authenticatedToken = $this->createMock(TokenInterface::class);
         $twoFactorToken = $this->createTwoFactorToken(self::FIREWALL_NAME, $authenticatedToken);
-        $this->stubTokenManagerHasToken($twoFactorToken);
+        $this->stubTokenStorageHasToken($twoFactorToken);
         $this->stubRequestIsCheckPath(true);
         $this->stubCsrfTokenIsValid();
         $this->stubHandlersReturnResponse();
@@ -384,7 +384,7 @@ class TwoFactorListenerTest extends TestCase
      */
     public function handle_authenticationException_dispatchFailureEvent(): void
     {
-        $this->stubTokenManagerHasToken($this->createTwoFactorToken());
+        $this->stubTokenStorageHasToken($this->createTwoFactorToken());
         $this->stubRequestIsCheckPath(true);
         $this->stubCsrfTokenIsValid();
         $this->stubAuthenticationManagerThrowsAuthenticationException();
@@ -403,7 +403,7 @@ class TwoFactorListenerTest extends TestCase
      */
     public function handle_authenticationException_setResponseFromFailureHandler(): void
     {
-        $this->stubTokenManagerHasToken($this->createTwoFactorToken());
+        $this->stubTokenStorageHasToken($this->createTwoFactorToken());
         $this->stubRequestIsCheckPath(true);
         $this->stubCsrfTokenIsValid();
         $this->stubAuthenticationManagerThrowsAuthenticationException();
@@ -427,7 +427,7 @@ class TwoFactorListenerTest extends TestCase
      */
     public function handle_csrfTokenInvalid_dispatchFailureEvent(): void
     {
-        $this->stubTokenManagerHasToken($this->createTwoFactorToken());
+        $this->stubTokenStorageHasToken($this->createTwoFactorToken());
         $this->stubRequestIsCheckPath(true);
         $this->stubCsrfTokenIsNotValid();
         $this->stubHandlersReturnResponse();
@@ -443,7 +443,7 @@ class TwoFactorListenerTest extends TestCase
     public function handle_authenticationStepSuccessful_dispatchSuccessEvent(): void
     {
         $twoFactorToken = $this->createTwoFactorToken();
-        $this->stubTokenManagerHasToken($twoFactorToken);
+        $this->stubTokenStorageHasToken($twoFactorToken);
         $this->stubRequestIsCheckPath(true);
         $this->stubCsrfTokenIsValid();
         $this->stubAuthenticationManagerReturnsToken($twoFactorToken); // Must be TwoFactorToken
@@ -463,7 +463,7 @@ class TwoFactorListenerTest extends TestCase
     public function handle_authenticationStepSuccessfulButNotCompleted_redirectToAuthenticationForm(): void
     {
         $twoFactorToken = $this->createTwoFactorToken();
-        $this->stubTokenManagerHasToken($twoFactorToken);
+        $this->stubTokenStorageHasToken($twoFactorToken);
         $this->stubRequestIsCheckPath(true);
         $this->stubCsrfTokenIsValid();
         $this->stubAuthenticationManagerReturnsToken($twoFactorToken); // Must be TwoFactorToken
@@ -484,7 +484,7 @@ class TwoFactorListenerTest extends TestCase
     public function handle_authenticationStepSuccessfulButNotCompleted_dispatchRequireEvent(): void
     {
         $twoFactorToken = $this->createTwoFactorToken();
-        $this->stubTokenManagerHasToken($twoFactorToken);
+        $this->stubTokenStorageHasToken($twoFactorToken);
         $this->stubRequestIsCheckPath(true);
         $this->stubCsrfTokenIsValid();
         $this->stubAuthenticationManagerReturnsToken($twoFactorToken); // Must be TwoFactorToken
@@ -503,7 +503,7 @@ class TwoFactorListenerTest extends TestCase
      */
     public function handle_twoFactorProcessComplete_returnResponseFromSuccessHandler(): void
     {
-        $this->stubTokenManagerHasToken($this->createTwoFactorToken());
+        $this->stubTokenStorageHasToken($this->createTwoFactorToken());
         $this->stubRequestIsCheckPath(true);
         $this->stubCsrfTokenIsValid();
         $this->stubAuthenticationManagerReturnsToken($this->createMock(TokenInterface::class)); // Not a TwoFactorToken
@@ -527,7 +527,7 @@ class TwoFactorListenerTest extends TestCase
      */
     public function handle_twoFactorProcessComplete_dispatchCompleteEvent(): void
     {
-        $this->stubTokenManagerHasToken($this->createTwoFactorToken());
+        $this->stubTokenStorageHasToken($this->createTwoFactorToken());
         $this->stubRequestIsCheckPath(true);
         $this->stubCsrfTokenIsValid();
         $this->stubAuthenticationManagerReturnsToken($this->createMock(TokenInterface::class)); // Not a TwoFactorToken
@@ -553,7 +553,7 @@ class TwoFactorListenerTest extends TestCase
             ->method('getUser')
             ->willReturn('user');
 
-        $this->stubTokenManagerHasToken($this->createTwoFactorToken());
+        $this->stubTokenStorageHasToken($this->createTwoFactorToken());
         $this->stubRequestIsCheckPath(true);
         $this->stubCsrfTokenIsValid();
         $this->stubRequestHasTrustedParameter(true);
@@ -580,7 +580,7 @@ class TwoFactorListenerTest extends TestCase
             ->method('getUser')
             ->willReturn('user');
 
-        $this->stubTokenManagerHasToken($this->createTwoFactorToken());
+        $this->stubTokenStorageHasToken($this->createTwoFactorToken());
         $this->stubRequestIsCheckPath(true);
         $this->stubCsrfTokenIsValid();
         $this->stubRequestHasTrustedParameter(true);
@@ -600,7 +600,7 @@ class TwoFactorListenerTest extends TestCase
      */
     public function handle_twoFactorProcessCompleteWithTrustedDisabled_notSetTrustedDevice(): void
     {
-        $this->stubTokenManagerHasToken($this->createTwoFactorToken());
+        $this->stubTokenStorageHasToken($this->createTwoFactorToken());
         $this->stubRequestIsCheckPath(true);
         $this->stubCsrfTokenIsValid();
         $this->stubRequestHasTrustedParameter(false);
@@ -629,7 +629,7 @@ class TwoFactorListenerTest extends TestCase
         $attributes = [TwoFactorTokenInterface::ATTRIBUTE_NAME_REMEMBER_ME_COOKIE => [$rememberMeCookie]];
         $twoFactorToken = $this->createTwoFactorToken(self::FIREWALL_NAME, null, $attributes);
 
-        $this->stubTokenManagerHasToken($twoFactorToken);
+        $this->stubTokenStorageHasToken($twoFactorToken);
         $this->stubRequestIsCheckPath(true);
         $this->stubCsrfTokenIsValid();
         $this->stubAuthenticationManagerReturnsToken($authenticatedToken); // Not a TwoFactorToken


### PR DESCRIPTION
Goal is to better integrate with the security infrastructure that is there in Symfony.

Effectively, a lot of logic is removed from TwoFactorListener, so that its only remaining responsibility is only the 2fa authentication process.

Access control in the "2fa in progress" phase is handled differently:

There's a new listener, which is injected on the firewall level, acting similar to Symfony's `Symfony\Component\Security\Http\Firewall\AccessListener`. It potentially denies access to a certain path during the "2fa in progress" phase. Redirecting to the 2fa form is now handled by a `kernel.exception` listener, which reacts to these `AccessDeniedException`s.

This architecture is cleaner (better separation of concerns) and better aligned with what Symfony is already doing for the matter of access control. As a side-effect, this prepares the bundle for upcoming authenticators-based security (#5).
