### PR TITLE
Clean up preparation listener state

### DIFF
--- a/src/bundle/Security/TwoFactor/Provider/TwoFactorProviderPreparationListener.php
+++ b/src/bundle/Security/TwoFactor/Provider/TwoFactorProviderPreparationListener.php
@@ -109,16 +109,20 @@ class TwoFactorProviderPreparationListener implements EventSubscriberInterface
         if (!$event->isMasterRequest()) {
             return;
         }
-        if (!($this->twoFactorToken instanceof TwoFactorTokenInterface)) {
+
+        $twoFactorToken = $this->twoFactorToken;
+        $this->twoFactorToken = null;
+
+        if (!($twoFactorToken instanceof TwoFactorTokenInterface)) {
             return;
         }
 
-        $providerName = $this->twoFactorToken->getCurrentTwoFactorProvider();
+        $providerName = $twoFactorToken->getCurrentTwoFactorProvider();
         if (null === $providerName) {
             return;
         }
 
-        $firewallName = $this->twoFactorToken->getProviderKey();
+        $firewallName = $twoFactorToken->getProviderKey();
 
         if ($this->preparationRecorder->isTwoFactorProviderPrepared($firewallName, $providerName)) {
             $this->logger->info(sprintf('Two-factor provider "%s" was already prepared.', $providerName));
@@ -126,7 +130,7 @@ class TwoFactorProviderPreparationListener implements EventSubscriberInterface
             return;
         }
 
-        $user = $this->twoFactorToken->getUser();
+        $user = $twoFactorToken->getUser();
         $this->providerRegistry->getProvider($providerName)->prepareAuthentication($user);
         $this->preparationRecorder->setTwoFactorProviderPrepared($firewallName, $providerName);
         $this->logger->info(sprintf('Two-factor provider "%s" prepared.', $providerName));

--- a/tests/Security/TwoFactor/Provider/TwoFactorProviderPreparationListenerTest.php
+++ b/tests/Security/TwoFactor/Provider/TwoFactorProviderPreparationListenerTest.php
@@ -213,6 +213,9 @@ class TwoFactorProviderPreparationListenerTest extends TestCase
 
         $this->listener->onTwoFactorForm($event);
         $this->listener->onKernelResponse($this->createResponseEvent());
+
+        // Request caused by redirect after full authentication
+        $this->listener->onKernelResponse($this->createResponseEvent());
     }
 
     /**


### PR DESCRIPTION
Needed for usage of 2fa in combination with PHP PM. As the listener service is reused, the state must be cleared, otherwise it leaks into the next request.
More specifically, in the next request the user is completely authenticated, but the listener would think that the 2fa process is still ongoing.