### PR TITLE
Altered backUpCode type

### DIFF
--- a/doc/backup_codes.md
+++ b/doc/backup_codes.md
@@ -12,7 +12,7 @@ composer require scheb/2fa-backup-code
 ## What it does
 
 Backup codes are one-time authentication codes, which can be used instead of the actual codes. They're meant as
-emergency codes, when the authentication device is not available and you have to pass the two-factor authentication
+emergency codes, when the authentication device is not available, and you have to pass the two-factor authentication
 process.
 
 Enable the feature in the configuration:
@@ -21,7 +21,7 @@ Enable the feature in the configuration:
 # config/packages/scheb_two_factor.yaml
 scheb_two_factor:
     backup_codes:
-        enabled: false  # If the backup code feature should be enabled
+        enabled: true  # If the backup code feature should be enabled
 ```
 
 Backup codes have to be provided from the user object. The user entity has to implement
@@ -38,9 +38,9 @@ use Scheb\TwoFactorBundle\Model\BackupCodeInterface;
 class User implements BackupCodeInterface
 {
     /**
-     * @ORM\Column(type="json_array")
+     * @ORM\Column(type="json")
      */
-    private $backupCodes;
+    private $backupCodes = [];
 
     // [...]
 
@@ -67,6 +67,21 @@ class User implements BackupCodeInterface
         if ($key !== false){
             unset($this->backupCodes[$key]);
         }
+    }
+
+    /**
+     * Add a backup code
+     *
+     * @param string $backUpCode
+     * @return mixed
+     */
+    public function addBackUpCode(string $backUpCode): self
+    {
+        if (!in_array($backUpCode, $this->backupCodes)) {
+            $this->backupCodes[] = $backUpCode;
+        }
+
+        return $this;
     }
 }
 ```


### PR DESCRIPTION
<!--
👍🎉 First off, thanks for taking the time to contribute! 🎉👍

Here are some tips for you:
 - Please follow the PR contribution guidelines: https://github.com/scheb/2fa/blob/5.x/CONTRIBUTING.md#creating-a-pull-request
 - Don't break backwards compatibility. If you have to, let's discuss! :)
 - Always add/update tests and ensure the build passes
-->

**Description**
<!--
Please provide a clear and concise description of the change.

For bug fixes:
 - What problem does the PR solve?
-->
The json_array type is deprecated and it should have a default value 
I also added a setter method to add new back up codes
The default value of backup_codes in config file should be true, because user is here to enable the bundle (IMO)