### PR TITLE
Document how to bypass 2FA entirely in a given context

### DIFF
--- a/doc/custom_conditions.md
+++ b/doc/custom_conditions.md
@@ -27,3 +27,27 @@ Register it as a service and configure the service name:
 scheb_two_factor:
     two_factor_condition: acme.custom_two_factor_condition
 ```
+
+Bypassing Two-Factor Authentication
+===================================
+
+If you simply wish to bypass 2FA in a given Authenticator context, setting the 
+`TwoFactorAuthenticator::FLAG_2FA_COMPLETE` attribute on the token will achieve this.
+
+For example, if you are building a [custom Authenticator](https://symfony.com/doc/5.2/security/experimental_authenticators.html#creating-a-custom-authenticator)
+this would bypass 2FA when the authenticator is used:
+
+```php
+class MyAuthenticator extends AbstractAuthenticator
+{
+    public function createAuthenticatedToken(PassportInterface $passport, string $firewallName): TokenInterface
+    {
+        $token = parent::createAuthenticatedToken($passport, $firewallName);
+        $token->setAttribute(TwoFactorAuthenticator::FLAG_2FA_COMPLETE, true);
+
+        return $token;
+    }
+    
+    // ...
+}
+```


### PR DESCRIPTION
This is partially a question too.. is this the best way? 

I first tried setting up a custom 2fa condition class but I did not have access to the Passport via the AuthenticationContextInterface, so it made things tricky as I couldn't easily add a TwoFactorBypassBadge or something to look at. I had to use the token, then when looking at internals further I found out that I may not even need a custom condition at all if I'm modifying the token already.. But IMO a passport badge would be more natural in the new authenticator.