### PR TITLE
Handle string env vars

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -25,5 +25,7 @@
         <ini name="error_reporting" value="-16385"/>
         <env name="ENABLE_2FA_TRUTHY" value="1"/>
         <env name="ENABLE_2FA_FALSY" value="0"/>
+        <env name="ENABLE_2FA_OFF_STR" value="off"/>
+        <env name="ENABLE_2FA_ON_STR" value="on"/>
     </php>
 </phpunit>

--- a/src/bundle/DependencyInjection/SchebTwoFactorExtension.php
+++ b/src/bundle/DependencyInjection/SchebTwoFactorExtension.php
@@ -170,6 +170,24 @@ class SchebTwoFactorExtension extends Extension
      */
     private function resolveFeatureFlag(ContainerBuilder $container, $value): bool
     {
-        return (bool) $container->resolveEnvPlaceholders($value, true);
+        $retValue = $container->resolveEnvPlaceholders($value, true);
+
+        if (\is_bool($retValue)) {
+            return $retValue;
+        }
+
+        if (\is_string($retValue)) {
+            $retValue = trim($retValue);
+
+            if ('false' === $retValue || 'off' === $retValue) {
+                return false;
+            }
+
+            if ('true' === $retValue || 'on' === $retValue) {
+                return true;
+            }
+        }
+
+        return (bool) $retValue;
     }
 }

--- a/tests/DependencyInjection/SchebTwoFactorExtensionTest.php
+++ b/tests/DependencyInjection/SchebTwoFactorExtensionTest.php
@@ -140,6 +140,60 @@ class SchebTwoFactorExtensionTest extends TestCase
     /**
      * @test
      */
+    public function load_offOrFalseStringEnvVarBasedConfig_setConfigValues(): void
+    {
+        $yaml = <<<EOF
+trusted_device:
+    enabled: "%env(ENABLE_2FA_OFF_STR)%"
+backup_codes:
+    enabled: "%env(ENABLE_2FA_OFF_STR)%"
+email:
+    enabled: "%env(ENABLE_2FA_OFF_STR)%"
+google:
+    enabled: "%env(ENABLE_2FA_OFF_STR)%"
+totp:
+    enabled: "%env(ENABLE_2FA_OFF_STR)%"
+EOF;
+        $parser = new Parser();
+        $this->extension->load([$parser->parse($yaml)], $this->container);
+
+        $this->assertHasParameter(false, 'scheb_two_factor.trusted_device.enabled');
+        $this->assertNotHasDefinition('scheb_two_factor.security.email.provider');
+        $this->assertNotHasAlias('scheb_two_factor.backup_code_manager');
+        $this->assertNotHasDefinition('scheb_two_factor.security.google.provider');
+        $this->assertNotHasDefinition('scheb_two_factor.security.totp.provider');
+    }
+
+    /**
+     * @test
+     */
+    public function load_onOrTrueStringEnvVarBasedConfig_setConfigValues(): void
+    {
+        $yaml = <<<EOF
+trusted_device:
+    enabled: "%env(ENABLE_2FA_ON_STR)%"
+backup_codes:
+    enabled: "%env(ENABLE_2FA_ON_STR)%"
+email:
+    enabled: "%env(ENABLE_2FA_ON_STR)%"
+google:
+    enabled: "%env(ENABLE_2FA_ON_STR)%"
+totp:
+    enabled: "%env(ENABLE_2FA_ON_STR)%"
+EOF;
+        $parser = new Parser();
+        $this->extension->load([$parser->parse($yaml)], $this->container);
+
+        $this->assertHasParameter(true, 'scheb_two_factor.trusted_device.enabled');
+        $this->assertHasDefinition('scheb_two_factor.security.email.provider');
+        $this->assertHasAlias('scheb_two_factor.backup_code_manager', 'scheb_two_factor.default_backup_code_manager');
+        $this->assertHasDefinition('scheb_two_factor.security.google.provider');
+        $this->assertHasDefinition('scheb_two_factor.security.totp.provider');
+    }
+
+    /**
+     * @test
+     */
     public function load_noAuthEnabled_notLoadServices(): void
     {
         $config = $this->getEmptyConfig();


### PR DESCRIPTION
**Description**

When you use environment variables in a configuration, they are resolved by default as strings. It isn't obvious that setting an env var to false creates a string and so its hard to know why it doesn't work. false/true are logically used defaults. Symfony doesn't allow us to use env(bool:VAR). 

Therefore we check for the string variables "false"|"off"|"true"|"on" and if found return the appropriate boolean. 

Fixes issue #86 