### PR TITLE
Fix deprecated in Symfony 5.3

### DIFF
--- a/src/bundle/Security/TwoFactor/Provider/TwoFactorProviderPreparationListener.php
+++ b/src/bundle/Security/TwoFactor/Provider/TwoFactorProviderPreparationListener.php
@@ -110,7 +110,7 @@ class TwoFactorProviderPreparationListener implements EventSubscriberInterface
             return;
         }
 
-        if (!$event->isMainRequest()) {
+        if (!$event->isMasterRequest()) {
             return;
         }
 

--- a/src/bundle/Security/TwoFactor/Provider/TwoFactorProviderPreparationListener.php
+++ b/src/bundle/Security/TwoFactor/Provider/TwoFactorProviderPreparationListener.php
@@ -106,7 +106,7 @@ class TwoFactorProviderPreparationListener implements EventSubscriberInterface
 
     public function onKernelResponse(ResponseEvent $event): void
     {
-        if (!$event->isMasterRequest()) {
+        if (!$event->isMainRequest()) {
             return;
         }
 

--- a/src/bundle/Security/TwoFactor/Provider/TwoFactorProviderPreparationListener.php
+++ b/src/bundle/Security/TwoFactor/Provider/TwoFactorProviderPreparationListener.php
@@ -106,6 +106,10 @@ class TwoFactorProviderPreparationListener implements EventSubscriberInterface
 
     public function onKernelResponse(ResponseEvent $event): void
     {
+        if (method_exists(KernelEvents::class, 'isMainRequest') && !$event->isMainRequest()) {
+            return;
+        }
+
         if (!$event->isMainRequest()) {
             return;
         }


### PR DESCRIPTION
Fixing:

> User Deprecated: Since symfony/http-kernel 5.3: "Symfony\Component\HttpKernel\Event\KernelEvent::isMasterRequest()" is deprecated, use "isMainRequest()" instead.
