### PR TITLE
Update TwoFactorProviderPreparationListener.php

### DIFF
--- a/src/bundle/Security/TwoFactor/Provider/TwoFactorProviderPreparationListener.php
+++ b/src/bundle/Security/TwoFactor/Provider/TwoFactorProviderPreparationListener.php
@@ -106,6 +106,10 @@ class TwoFactorProviderPreparationListener implements EventSubscriberInterface
 
     public function onKernelResponse(ResponseEvent $event): void
     {
+        if (method_exists(KernelEvents::class, 'isMainRequest') && !$event->isMainRequest()) {
+            return;
+        }
+
         if (!$event->isMasterRequest()) {
             return;
         }

--- a/src/bundle/Security/TwoFactor/Provider/TwoFactorProviderPreparationListener.php
+++ b/src/bundle/Security/TwoFactor/Provider/TwoFactorProviderPreparationListener.php
@@ -106,12 +106,14 @@ class TwoFactorProviderPreparationListener implements EventSubscriberInterface
 
     public function onKernelResponse(ResponseEvent $event): void
     {
-        if (method_exists(KernelEvents::class, 'isMainRequest') && !$event->isMainRequest()) {
-            return;
-        }
-
-        if (!$event->isMasterRequest()) {
-            return;
+        if (method_exists(KernelEvents::class, 'isMainRequest')) {
+            if (!$event->isMainRequest()) {
+                return;
+            }
+        } else {
+            if (!$event->isMasterRequest()) {
+                return;
+            }
         }
 
         // Unset the token from context. This is important for environments where this instance of the class is reused


### PR DESCRIPTION
fixing:

> User Deprecated: Since symfony/http-kernel 5.3: "Symfony\Component\HttpKernel\Event\KernelEvent::isMasterRequest()" is deprecated, use "isMainRequest()" instead.

on Symfony 5.3