### PR TITLE
check for isMainRequest on the correct class

### DIFF
--- a/src/bundle/Security/TwoFactor/Provider/TwoFactorProviderPreparationListener.php
+++ b/src/bundle/Security/TwoFactor/Provider/TwoFactorProviderPreparationListener.php
@@ -11,7 +11,7 @@ use Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorAuthenticationEvent;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorAuthenticationEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
-use Symfony\Component\HttpKernel\KernelEvent;
+use Symfony\Component\HttpKernel\Event\KernelEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\AuthenticationEvents;

--- a/src/bundle/Security/TwoFactor/Provider/TwoFactorProviderPreparationListener.php
+++ b/src/bundle/Security/TwoFactor/Provider/TwoFactorProviderPreparationListener.php
@@ -11,6 +11,7 @@ use Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorAuthenticationEvent;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorAuthenticationEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\AuthenticationEvents;
@@ -114,7 +115,7 @@ class TwoFactorProviderPreparationListener implements EventSubscriberInterface
     public function onKernelResponse(ResponseEvent $event): void
     {
         // Compatibility for Symfony >= 5.3
-        if (method_exists(KernelEvents::class, 'isMainRequest')) {
+        if (method_exists(KernelEvent::class, 'isMainRequest')) {
             if (!$event->isMainRequest()) {
                 return;
             }


### PR DESCRIPTION
As commented in https://github.com/scheb/2fa/pull/89#issuecomment-847347811

> While tests are green now, this isn't fixing the deprecation issue. The method isMasterRequest is still called when isMainRequest is true.

Looks like you made a simple typo and reused the already imported plural class name `KernelEvents`

Today in my Symfony 5.3.0 project I have this logged deprecation in my dev env.

<img width="1079" alt="Screenshot 2021-06-02 at 11 27 18" src="https://user-images.githubusercontent.com/400092/120465133-8d1d8e80-c395-11eb-9b46-5f4463775805.png">

On checking `isMainRequest` is not a method in `Symfony\Component\HttpKernel\KernelEvents` (the plural of events) but is a method on `Symfony\Component\HttpKernel\KernelEvent` (the singular of event)

This PR corrects the typo, which in turn allows the correct evaluation in `method_exists` and then correctly calls `isMainRequest ` and therefore no more logged deprecation. 