### PR TITLE
Return roles of authenticatedToken in TwoFactorToken

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ vendor/
 composer.lock
 # PHPCS Fixer
 .php-cs-fixer.cache
+.php_cs.cache
 # PHPUnit
 .phpunit.result.cache
 # Test application

--- a/tests/Security/Authentication/Token/TwoFactorTokenTest.php
+++ b/tests/Security/Authentication/Token/TwoFactorTokenTest.php
@@ -26,7 +26,7 @@ class TwoFactorTokenTest extends TestCase
             'provider2',
         ];
         $this->twoFactorToken = new TwoFactorToken(
-            $this->createMock(TokenInterface::class),
+            $this->createConfiguredMock(TokenInterface::class, ['getRoleNames' => ['ROLE_USER']]),
             null,
             self::FIREWALL_NAME,
             $twoFactorProviders
@@ -172,5 +172,115 @@ class TwoFactorTokenTest extends TestCase
         $unserializedToken = unserialize(serialize($twoFactorToken));
 
         $this->assertEquals($twoFactorToken, $unserializedToken);
+    }
+
+    /**
+     * @test
+     */
+    public function getRoles_getRoleNamesExists_rolesReturned(): void
+    {
+        if (!method_exists(TokenInterface::class, 'getRoleNames')) {
+            self::markTestSkipped('TokenInterface::getRoleNames() is required');
+        }
+
+        $twoFactorToken = new TwoFactorToken(
+            $this->createConfiguredMock(TokenInterface::class, ['getRoleNames' => ['ROLE_USER']]),
+            null,
+            self::FIREWALL_NAME,
+            ['2faProvider']
+        );
+        $roles = $twoFactorToken->getRoles();
+        $this->assertIsArray($roles);
+        $this->assertCount(1, $roles);
+        $this->assertContains('ROLE_USER', $roles);
+    }
+
+    /**
+     * @test
+     */
+    public function getRoleNames_getRoleNamesExists_rolesReturned(): void
+    {
+        if (!method_exists(TokenInterface::class, 'getRoleNames')) {
+            self::markTestSkipped('TokenInterface::getRoleNames() is required');
+        }
+
+        $twoFactorToken = new TwoFactorToken(
+            $this->createConfiguredMock(TokenInterface::class, ['getRoleNames' => ['ROLE_USER']]),
+            null,
+            self::FIREWALL_NAME,
+            ['2faProvider']
+        );
+        $roles = $twoFactorToken->getRoleNames();
+        $this->assertIsArray($roles);
+        $this->assertCount(1, $roles);
+        $this->assertContains('ROLE_USER', $roles);
+    }
+
+    /**
+     * @test
+     */
+    public function getRoles_getRolesExists_rolesReturned(): void
+    {
+        if (!method_exists(TokenInterface::class, 'getRoles')) {
+            self::markTestSkipped('TokenInterface::getRoles() is required');
+        }
+
+        $twoFactorToken = new TwoFactorToken(
+            $this->createConfiguredMock(TokenInterface::class, ['getRoles' => ['ROLE_USER']]),
+            null,
+            self::FIREWALL_NAME,
+            ['2faProvider']
+        );
+        $roles = $twoFactorToken->getRoles();
+        $this->assertIsArray($roles);
+        $this->assertCount(1, $roles);
+        $this->assertContains('ROLE_USER', $roles);
+    }
+
+    /**
+     * @test
+     */
+    public function getRoleNames_getRolesExists_rolesReturned(): void
+    {
+        if (!method_exists(TokenInterface::class, 'getRoles')) {
+            self::markTestSkipped('TokenInterface::getRoles() is required');
+        }
+
+        $twoFactorToken = new TwoFactorToken(
+            $this->createConfiguredMock(TokenInterface::class, ['getRoles' => ['ROLE_USER']]),
+            null,
+            self::FIREWALL_NAME,
+            ['2faProvider']
+        );
+        $roles = $twoFactorToken->getRoleNames();
+        $this->assertIsArray($roles);
+        $this->assertCount(1, $roles);
+        $this->assertContains('ROLE_USER', $roles);
+    }
+
+    /**
+     * @test
+     */
+    public function getRoleNames_getRolesReturnsUnknownRoleObjects_nothingReturned(): void
+    {
+        if (!method_exists(TokenInterface::class, 'getRoles')) {
+            self::markTestSkipped('TokenInterface::getRoles() is required');
+        }
+
+        $twoFactorToken = new TwoFactorToken(
+            $this->createConfiguredMock(TokenInterface::class, [
+                'getRoles' => [
+                    new class() {
+                    },
+                ],
+            ]),
+            null,
+            self::FIREWALL_NAME,
+            ['2faProvider']
+        );
+
+        $roles = $twoFactorToken->getRoleNames();
+        $this->assertIsArray($roles);
+        $this->assertEmpty($roles);
     }
 }


### PR DESCRIPTION
<!--
👍🎉 First off, thanks for taking the time to contribute! 🎉👍

Here are some tips for you:
 - Please follow the PR contribution guidelines: https://github.com/scheb/2fa/blob/5.x/CONTRIBUTING.md#creating-a-pull-request
 - Don't break backwards compatibility. If you have to, let's discuss! :)
 - Always add/update tests and ensure the build passes
-->

**Description**
The `TwoFactorToken` currently does not return the roles of the `authenticatedToken`.  This resulted in a bug in our application.  To resolve this, I modified the class to pass through the roles of the underlying token.

***Our problematic situation***
1. We have a `AuthenticationSuccessSubscriber` listening to `AuthenticationEvents::AUTHENTICATION_SUCCESS`
2. In this subscriber, we check if the logged in user has access to certain roles using `\Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface::isGranted()`
3. This propagates the decision to `Symfony\Component\Security\Core\Authorization\Voter\RoleVoter`
4. This voter fetches the roles from the supplied token, which was the `TwoFactorToken`
5. The TwoFactorToken returned an empty array, implying the current user does not have any roles available.
6. The RoleVoter denies access to the role

***With new implementation***
5. The TwoFactorToken returns the roles  of the authenticatedToken
6. The RoleVoter grants access to the role


***Additional details***
Previously, if the specific user did not have 2fa configured, it would work as expected, since then the supplied token would not be a TwoFactorToken and the RoleVoter had access to the roles of the user.

This resulted in a different result from the RoleVoter depending on the user having 2fa configured or not.

***Follow up***
If you have any more questions or need some implementation of this PR changed, I'm happy to help.

I added an entry to `.gitignore` since php-cs-fixer generated a different cache-file for me.
