### PR TITLE
Avoid deprecation warnings in Symfony 5.3

### DIFF
--- a/src/bundle/Security/Authentication/Provider/AuthenticationProviderDecorator.php
+++ b/src/bundle/Security/Authentication/Provider/AuthenticationProviderDecorator.php
@@ -105,7 +105,12 @@ class AuthenticationProviderDecorator implements AuthenticationProviderInterface
 
     private function getRequest(): Request
     {
-        $request = $this->requestStack->getMasterRequest();
+        // Compatibility for Symfony >= 5.3
+        if (method_exists(RequestStack::class, 'getMainRequest')) {
+            $request = $this->requestStack->getMainRequest();
+        } else {
+            $request = $this->requestStack->getMasterRequest();
+        }
         if (null === $request) {
             throw new \RuntimeException('No request available');
         }

--- a/src/bundle/Security/TwoFactor/Event/AuthenticationTokenListener.php
+++ b/src/bundle/Security/TwoFactor/Event/AuthenticationTokenListener.php
@@ -75,7 +75,12 @@ class AuthenticationTokenListener implements EventSubscriberInterface
 
     private function getRequest(): Request
     {
-        $request = $this->requestStack->getMasterRequest();
+        // Compatibility for Symfony >= 5.3
+        if (method_exists(RequestStack::class, 'getMainRequest')) {
+            $request = $this->requestStack->getMainRequest();
+        } else {
+            $request = $this->requestStack->getMasterRequest();
+        }
         if (null === $request) {
             throw new \RuntimeException('No request available');
         }

--- a/src/trusted-device/Security/TwoFactor/Trusted/TrustedDeviceTokenStorage.php
+++ b/src/trusted-device/Security/TwoFactor/Trusted/TrustedDeviceTokenStorage.php
@@ -135,7 +135,12 @@ class TrustedDeviceTokenStorage
 
     private function getRequest(): Request
     {
-        $request = $this->requestStack->getMasterRequest();
+        // Compatibility for Symfony >= 5.3
+        if (method_exists(RequestStack::class, 'getMainRequest')) {
+            $request = $this->requestStack->getMainRequest();
+        } else {
+            $request = $this->requestStack->getMasterRequest();
+        }
         if (null === $request) {
             throw new \RuntimeException('No request available');
         }

--- a/tests/Security/Authentication/Provider/AuthenticationProviderDecoratorTest.php
+++ b/tests/Security/Authentication/Provider/AuthenticationProviderDecoratorTest.php
@@ -59,9 +59,15 @@ class AuthenticationProviderDecoratorTest extends TestCase
         $this->firewallMap = $this->createMock(FirewallMap::class);
 
         $this->requestStack = $this->createMock(RequestStack::class);
+        // Compatibility for Symfony >= 5.3
+        if (method_exists(RequestStack::class, 'getMainRequest')) {
+            $method = 'getMainRequest';
+        } else {
+            $method = 'getMasterRequest';
+        }
         $this->requestStack
             ->expects($this->any())
-            ->method('getMasterRequest')
+            ->method($method)
             ->willReturn($this->createMock(Request::class));
 
         $this->decorator = new AuthenticationProviderDecorator(

--- a/tests/Security/TwoFactor/Event/AuthenticationTokenListenerTest.php
+++ b/tests/Security/TwoFactor/Event/AuthenticationTokenListenerTest.php
@@ -48,9 +48,15 @@ class AuthenticationTokenListenerTest extends TestCase
         $this->authenticationContextFactory = $this->createMock(AuthenticationContextFactoryInterface::class);
 
         $this->requestStack = $this->createMock(RequestStack::class);
+        // Compatibility for Symfony >= 5.3
+        if (method_exists(RequestStack::class, 'getMainRequest')) {
+            $method = 'getMainRequest';
+        } else {
+            $method = 'getMasterRequest';
+        }
         $this->requestStack
             ->expects($this->any())
-            ->method('getMasterRequest')
+            ->method($method)
             ->willReturn($this->createMock(Request::class));
 
         $this->listener = new AuthenticationTokenListener(

--- a/tests/Security/TwoFactor/Trusted/TrustedDeviceTokenStorageTest.php
+++ b/tests/Security/TwoFactor/Trusted/TrustedDeviceTokenStorageTest.php
@@ -35,9 +35,15 @@ class TrustedDeviceTokenStorageTest extends TestCase
         $this->tokenEncoder = $this->createMock(TrustedDeviceTokenEncoder::class);
         $this->request = new Request();
         $requestStack = $this->createMock(RequestStack::class);
+        // Compatibility for Symfony >= 5.3
+        if (method_exists(RequestStack::class, 'getMainRequest')) {
+            $method = 'getMainRequest';
+        } else {
+            $method = 'getMasterRequest';
+        }
         $requestStack
             ->expects($this->any())
-            ->method('getMasterRequest')
+            ->method($method)
             ->willReturn($this->request);
 
         $this->tokenStorage = new TrustedDeviceTokenStorage($requestStack, $this->tokenEncoder, 'cookieName');


### PR DESCRIPTION
Not sure if method_exists is typically the way you'd do that, but hopefully this works.