### PR TITLE
Minor reStructuredText syntax fixes/improvements

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -28,13 +28,13 @@ least similar, as long as it lets you configure a custom success handler.
 
 You need to implement 4 classes:
 
-1) A custom success handler for the authentication mechanism
-2) A custom "two-factor authentication required" handler for the two-factor authentication
-3) A custom success handler for the two-factor authentication
-4) A custom failure handler for the two-factor authentication
+#. A custom success handler for the authentication mechanism
+#. A custom "two-factor authentication required" handler for the two-factor authentication
+#. A custom success handler for the two-factor authentication
+#. A custom failure handler for the two-factor authentication
 
 Configuration
-^^^^^^^^^^^^^
+~~~~~~~~~~~~~
 
 Please make sure the following configuration options are set on your firewall:
 
@@ -50,7 +50,7 @@ Please make sure the following configuration options are set on your firewall:
                    prepare_on_access_denied: true
 
 1) Response on login
-^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~
 
 This first response is returned after the user logged in. Without two-factor authentication, it would either return
 a "login success" or "login failure" response. With two-factor authentication, you eventually need to return a third
@@ -100,7 +100,7 @@ Register it as a service and configure it as a custom ``success_handler`` for th
                    success_handler: your_api_success_handler
 
 2) Response to require two-factor authentication
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You need a response that is returned when the user requests a path, but it is not accessible (yet), because the user has
 to complete two-factor authentication first. This could be the same as your "access denied" response.
@@ -141,7 +141,7 @@ Register it as a service and configure it as the ``required_handler`` of the ``t
                    authentication_required_handler: your_api_2fa_required_handler
 
 3) Response when two-factor authentication was successful
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You need a response that is returned when two-factor authentication was completed successfully and the user is now
 fully authenticated. Implement another success handler for it:
@@ -179,7 +179,7 @@ Register it as a service and configure it as the ``success_handler`` of the ``tw
                    success_handler: your_api_2fa_success_handler
 
 4) Response when two-factor authentication failed
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You need a response that is returned when two-factor authentication was tried, but authentication failed for some
 reason. Implement a failure handler for it:
@@ -220,14 +220,14 @@ Sending the 2fa code
 --------------------
 
 POST data
-^^^^^^^^^
+~~~~~~~~~
 
 In the API use-case, you'd usually send the two-factor authentication code to the "2fa check" path that you have
 configured in your firewall settings. The code is sent over the same way as if you'd send it from the 2fa form - a
 ``POST`` request with post data in the payload.
 
 JSON data
-^^^^^^^^^
+~~~~~~~~~
 
 To better integrate with JSON-style APIs, the bundle also accepts ``POST`` requests with a JSON payload. Make sure you
 send a JSON-encoded payload with a JSON content type, such as ``application/json``.

--- a/doc/backup_codes.rst
+++ b/doc/backup_codes.rst
@@ -6,7 +6,7 @@ Prerequisites
 
 To make use of this feature, you have to install ``scheb/2fa-backup-code``.
 
-.. code-block:: bash
+.. code-block:: terminal
 
    composer require scheb/2fa-backup-code
 

--- a/doc/csrf_protection.rst
+++ b/doc/csrf_protection.rst
@@ -26,7 +26,7 @@ Then, in the firewall's ``two_factor`` security configuration need to enable CSR
 Make sure you add the extra field for the CSRF token in the authentication form. The code from the default template will
 do the job:
 
-.. code-block:: html
+.. code-block:: html+twig
 
    {% if isCsrfProtectionEnabled %}
        <input type="hidden" name="{{ csrfParameterName }}" value="{{ csrf_token(csrfTokenId) }}">

--- a/doc/custom_conditions.rst
+++ b/doc/custom_conditions.rst
@@ -29,7 +29,7 @@ Register it as a service and configure the service name:
        two_factor_condition: acme.custom_two_factor_condition
 
 Bypassing Two-Factor Authentication
-===================================
+-----------------------------------
 
 ℹ️ This approach only works when you're using Symfony's authenticator-based security system.
 

--- a/doc/events.rst
+++ b/doc/events.rst
@@ -4,7 +4,7 @@ Events
 The bundle dispatches the following events during the authentication process:
 
 ``scheb_two_factor.authentication.require``
------------------------------------------------
+-------------------------------------------
 
 Constant: ``Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorAuthenticationEvents::REQUIRE``
 
@@ -15,21 +15,21 @@ but there's another two-factor step required (multi-factor authentication).
 Usually, when this event is dispatched, the request is redirected to the two-factor authentication form.
 
 ``scheb_two_factor.authentication.form``
---------------------------------------------
+----------------------------------------
 
 Constant: ``Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorAuthenticationEvents::FORM``
 
 Is dispatched when the two-factor authentication form is shown.
 
 ``scheb_two_factor.authentication.attempt``
------------------------------------------------
+-------------------------------------------
 
 Constant: ``Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorAuthenticationEvents::ATTEMPT``
 
 Is dispatched when two-factor authentication is attempted, right before checking the code.
 
 ``scheb_two_factor.authentication.success``
------------------------------------------------
+-------------------------------------------
 
 Constant: ``Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorAuthenticationEvents::SUCCESS``
 
@@ -37,14 +37,14 @@ Is dispatched when two-factor authentication was successful for a single provide
 two-factor process is completed.
 
 ``scheb_two_factor.authentication.failure``
------------------------------------------------
+-------------------------------------------
 
 Constant: ``Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorAuthenticationEvents::FAILURE``
 
 Is dispatched when the given two-factor authentication code was incorrect.
 
 ``scheb_two_factor.authentication.complete``
-------------------------------------------------
+--------------------------------------------
 
 Constant: ``Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorAuthenticationEvents::COMPLETE``
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -44,7 +44,6 @@ challenged to enter a valid two-factor authentication code. Only when that code 
 granted.
 
 .. image:: authentication-process.png
-   :target: authentication-process.png
    :alt: Authentication process
 
 To represent the state between login and a valid two-factor code being entered, the bundle introduces the role-like

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -11,7 +11,7 @@ Installation
 ------------
 
 Step 1: Install with Composer
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The bundle is organized into sub-repositories, so you can choose the exact feature set you need and keep installed
 dependencies to a minimum.
@@ -19,19 +19,19 @@ dependencies to a minimum.
 If you're using `Symfony Flex <https://flex.symfony.com/>`_, use the following command to install the bundle via
 `Composer <https://getcomposer.org>`_:
 
-.. code-block::
+.. code-block:: terminal
 
    composer require 2fa
 
 Alternatively, use the following Composer command:
 
-.. code-block::
+.. code-block:: terminal
 
    composer require scheb/2fa-bundle
 
 Optionally, install any additional packages to extend the bundle's feature according to your needs:
 
-.. code-block::
+.. code-block:: terminal
 
    composer require scheb/2fa-backup-code            # Add backup code feature
    composer require scheb/2fa-trusted-device         # Add trusted devices feature
@@ -41,9 +41,11 @@ Optionally, install any additional packages to extend the bundle's feature accor
    composer require scheb/2fa-qr-code                # Add to render QR-codes for Google Authenticator / TOTP
 
 Step 2: Enable the bundle
-^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
-ℹ️ If you're using Symfony Flex, this step happens automatically.
+.. note::
+
+    If you're using Symfony Flex, this step happens automatically.
 
 Enable this bundle in your ``config/bundles.php``:
 
@@ -59,8 +61,10 @@ Enable this bundle in your ``config/bundles.php``:
 Step 3: Define routes
 ^^^^^^^^^^^^^^^^^^^^^
 
-ℹ️ If you're using Symfony Flex, a default config file is created automatically. Though make sure the preconfigured paths
-are located within your firewall's ``pattern``.
+.. note::
+
+    If you're using Symfony Flex, a default config file is created automatically. Though make sure the
+    preconfigured paths are located within your firewall's ``pattern``.
 
 In ``config/routes/scheb_2fa.yaml`` (create the file if it doesn't exist) you need to add two routes:
 
@@ -87,7 +91,7 @@ If you have multiple firewalls with two-factor authentication, each one needs it
 check routes that must be located within the associated firewall's path ``pattern``.
 
 Step 4: Configure the firewall
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Enable two-factor authentication **per firewall** and configure ``access_control`` for the 2fa routes:
 
@@ -114,7 +118,7 @@ Enable two-factor authentication **per firewall** and configure ``access_control
 More per-firewall configuration options can be found in the :doc:`configuration reference </configuration>`.
 
 Step 5: Configure the security tokens
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Your firewall may offer different ways how to login. By default (without any configuration), the bundle is listening
 only to these tokens:
@@ -137,16 +141,16 @@ If you want to support two-factor authentication with another login method, you 
            - Acme\AuthenticationBundle\Token\CustomAuthenticationToken
 
 Step 6: Enable two-factor authentication methods
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you have installed any of the two-factor authentication methods provided as sub-packages, you have to enable these
 separately. Read how to do this for:
 
-* :doc:``scheb/2fa-totp`` `TOTP authentication </providers/totp>`
-* :doc:``scheb/2fa-google-authenticator`` `Google Authenticator </providers/google>`
-* :doc:``scheb/2fa-email`` `Code-via-Email authentication </providers/email>`
+* :doc:`scheb/2fa-totp TOTP authentication </providers/totp>`
+* :doc:`scheb/2fa-google-authenticator Google Authenticator </providers/google>`
+* :doc:`scheb/2fa-email Code-via-Email authentication </providers/email>`
 
 Step 7: Detailed configuration
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You probably want to configure some details of the bundle. See the :doc:`all configuration options </configuration>`.

--- a/doc/providers/custom.rst
+++ b/doc/providers/custom.rst
@@ -20,7 +20,7 @@ You have to create a service, which implements the
 ``Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderInterface`` interface. It requires these methods:
 
 beginAuthentication
-^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: php
 
@@ -41,7 +41,7 @@ This method is where you should to the preparation work for your two-factor prov
 generating a code and sending it to the user.
 
 validateAuthenticationCode
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: php
 
@@ -51,7 +51,7 @@ This method is responsible for validating the authentication code entered by the
 correct or ``false`` when it was wrong.
 
 getFormRenderer
-^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~
 
 .. code-block:: php
 
@@ -76,25 +76,25 @@ Now you have to register your two-factor provider class as a service.
 A tag named ``scheb_two_factor.provider`` will make your provider available to the bundle. The tag attribute ``alias``
 has to be set and must be an application-wide unique identifier for the authentication provider.
 
-**Please note**: The aliases ``google``, ``totp`` and ``email`` are reserved by the authentication methods that are
-included in the bundle.
+.. note::
 
-**YAML Configuration**:
+    The aliases ``google``, ``totp`` and ``email`` are reserved by the authentication methods that are
+    included in the bundle.
 
-.. code-block:: yaml
+.. configuration-block::
 
-   # config/services.yaml
-   services:
-       # ...
-       acme.custom_two_factor_provider:
-           class: Acme\Demo\MyTwoFactorProvider
-           tags:
-               - { name: scheb_two_factor.provider, alias: acme_two_factor_provider }
+    .. code-block:: yaml
 
-**XML Configuration (alternatively)**:
+       # config/services.yaml
+       services:
+           # ...
+           acme.custom_two_factor_provider:
+               class: Acme\Demo\MyTwoFactorProvider
+               tags:
+                   - { name: scheb_two_factor.provider, alias: acme_two_factor_provider }
 
-.. code-block:: xml
+    .. code-block:: xml
 
-   <service id="acme.custom_two_factor_provider" class="Acme\Demo\MyTwoFactorProvider">
-       <tag name="scheb_two_factor.provider" alias="acme_two_factor_provider" />
-   </service>
+       <service id="acme.custom_two_factor_provider" class="Acme\Demo\MyTwoFactorProvider">
+           <tag name="scheb_two_factor.provider" alias="acme_two_factor_provider" />
+       </service>

--- a/doc/providers/email.rst
+++ b/doc/providers/email.rst
@@ -195,7 +195,7 @@ Custom Form Rendering
 
 There are certain cases when it's not enough to just change the template. For example, you're using two-factor
 authentication on multiple firewalls and you need to
-:doc:`render the form differently for each firewall </../firewall_template>`. In such a case you can implement a form
+:doc:`render the form differently for each firewall </firewall_template>`. In such a case you can implement a form
 renderer to fully customize the rendering logic.
 
 Create a class implementing ``Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorFormRendererInterface``:

--- a/doc/providers/totp.rst
+++ b/doc/providers/totp.rst
@@ -13,8 +13,10 @@ Several parameters can be customized:
 * The period (default = ``30`` seconds)
 * Custom parameters can be added
 
-ℹ️ Use the default values to configure TOTP compatible with Google Authenticator (6 digits, sha1 algorithm, 30 seconds
-period).
+.. tip::
+
+    Use the default values to configure TOTP compatible with Google Authenticator (6 digits, sha1 algorithm, 30 seconds
+    period).
 
 How authentication works
 ------------------------
@@ -50,8 +52,10 @@ Your user entity has to implement ``Scheb\TwoFactorBundle\Model\Totp\TwoFactorIn
 user, generate a secret and define the TOTP configuration. TOTP let's you configure the number of digits, the algorithm
 and the period of the temporary codes.
 
-**We warned, custom configurations will not be compatible with the defaults of Google Authenticator app any more. You
-will have to use another application (e.g. FreeOTP on Android).**
+.. caution::
+
+    We warned, custom configurations will not be compatible with the defaults of Google Authenticator app any more. You
+    will have to use another application (e.g. FreeOTP on Android).
 
 .. code-block:: php
 
@@ -138,7 +142,7 @@ Custom Form Rendering
 
 There are certain cases when it's not enough to just change the template. For example, you're using two-factor
 authentication on multiple firewalls and you need to
-:doc:`render the form differently for each firewall </../firewall_template>`. In such a case you can implement a form
+:doc:`render the form differently for each firewall </firewall_template>`. In such a case you can implement a form
 renderer to fully customize the rendering logic.
 
 Create a class implementing ``Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorFormRendererInterface``:

--- a/doc/troubleshooting.rst
+++ b/doc/troubleshooting.rst
@@ -16,9 +16,9 @@ The principle of TOTP/Google Authenticator is that both systems - the server and
 authentication code from a shared secret and the current time. If one of those two components isn't in sync, they'll
 generate a different code. Therefore:
 
-1) Most common problem: Make sure the server time and the time on your device are in sync with the actual current time
-2) Make sure the secret used in your device matches the secret configured for the account on the server
-3) If you're using TOTP, make sure the app is actually supporting the specific TOTP configuration you're using. **The
+#. Most common problem: Make sure the server time and the time on your device are in sync with the actual current time
+#. Make sure the secret used in your device matches the secret configured for the account on the server
+#. If you're using TOTP, make sure the app is actually supporting the specific TOTP configuration you're using. **The
    Google Authenticator app supports only one specific TOTP configuration (6-digit code, 30sec window, sha1 algorithm)**
 
 The generated authentication code has a time window in which it is valid (30 seconds in Google Authenticator, for TOTP
@@ -52,14 +52,14 @@ Logout redirects back to the two-factor authentication form
 -----------------------------------------------------------
 
 Problem
-^^^^^^^
+~~~~~~~
 
 When the two-factor authentication form is shown, you want to cancel the two-factor authentication process. You click
 the "cancel" link, which should execute a logout. It does not execute the logout, but redirects back to the two-factor
 authentication form.
 
 Solution
-^^^^^^^^
+~~~~~~~~
 
 If you see such behavior, the ``access_control`` rules from the security configuration don't allow accessing the logout
 path. Your logout path must be accessible to user with any authentication state, which is usually done by allowing it
@@ -86,33 +86,37 @@ Not logged in after completing two-factor authentication
 --------------------------------------------------------
 
 Problem
-^^^^^^^
+~~~~~~~
 
 After you logged in and have successfully passed the two-factor authentication process, you're not logged in. Either you
 are redirected back to the login page or the page is shown with the authenticated user missing.
 
 Troubleshooting
-^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~
 
-1) Disable two-factor authentication by commenting out all ``two_factor`` settings in the security firewall
+#. Disable two-factor authentication by commenting out all ``two_factor`` settings in the security firewall
    configuration. Try to login. Does it work?
 
-* Yes, it works -> Continue with 2)
-* No, it does not work -> Your login process is broken.
+   Yes, it works
+       Continue with 2)
+   No, it does not work
+       Your login process is broken.
 
-  * **Solution:** Can't exactly tell what's wrong. Continue debugging the login issue. Solve this issue first,
-    before you re-enable two-factor authentication.
+       **Solution:** Can't exactly tell what's wrong. Continue debugging the login issue. Solve this issue first,
+       before you re-enable two-factor authentication.
 
-2) Revert the changes from 1). Debug the security token on the two-factor authentication form page by ``var_dump``-ing
+#. Revert the changes from 1). Debug the security token on the two-factor authentication form page by ``var_dump``-ing
    it or any other suitable method.
 
    The token should be of type ``TwoFactorToken`` and the field ``authenticatedToken`` should contain an authenticated
    security token. Does that authenticated token have ``authenticated``=``false`` set?
 
-* Yes -> Your authenticated token was flagged as invalid. Follow solution below.
-* No -> Continue with 3)
+   Yes
+       Your authenticated token was flagged as invalid. Follow solution below.
+   No
+       Continue with 3)
 
-3) After completing two-factor authentication, when you end up in the unauthenticated state, check the last request few
+#. After completing two-factor authentication, when you end up in the unauthenticated state, check the last request few
    requests in the Symfony profiler.
 
    For each of the requests, go to Logs -> Debug.
@@ -120,10 +124,12 @@ Troubleshooting
    Does it say ``Cannot refresh token because user has changed`` or ``Token was deauthenticated after trying to refresh
    it``?
 
-* Yes -> Your authenticated token was flagged as invalid. Follow solution below.
-* No -> Unknown issue. Try to reach out for help by
-  :doc:`creating an issue </https://github.com/scheb/2fa/issues/new?labels=Support&template=support-request>` and let us
-  know what you've already tested.
+   Yes
+       Your authenticated token was flagged as invalid. Follow solution below.
+   No
+       Unknown issue. Try to reach out for help by
+      :doc:`creating an issue </https://github.com/scheb/2fa/issues/new?labels=Support&template=support-request>` and let us
+       know what you've already tested.
 
 **Solution to: Your authenticated token was flagged as invalid**
 
@@ -140,13 +146,13 @@ Two-factor authentication form is not shown after login
 -------------------------------------------------------
 
 Problem
-^^^^^^^
+~~~~~~~
 
 After successful login, the two-factor authentication form is not shown. Instead, you're either logged in or you see
 a different page from your application.
 
 Basic checks
-^^^^^^^^^^^^
+~~~~~~~~~~~~
 
 * Your login page belongs to the firewall, which has two-factor authentication configured.
 * The paths of login page, login check, 2fa and 2fa check are all located with the firewall's path ``pattern``.
@@ -158,7 +164,7 @@ Basic checks
     ``getGoogleAuthenticatorSecret()`` method must return a secret code.
 
 Is ``access_control`` configured properly?
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To make the two-factor authentication form accessible during the two-factor authentication process, you have to
 configure a ``access_control`` rule for the 2fa routes:
@@ -183,7 +189,7 @@ two-factor authentication form path. If you have additional options, such as ``h
 matching as well.
 
 Is there something special about your security setup?
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Often issues originate from a customization in the application's security setup, which is usually related to how roles
 are granted. Examples of such issue are:
@@ -210,55 +216,58 @@ The solution to this problem is usually to skip any customization for a security
    }
 
 Troubleshooting
-^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~
 
-1) Is a ``TwoFactorToken`` present after the login?
+#. Is a ``TwoFactorToken`` present after the login?
 
-* Yes -> Continue with 2)
-* No -> Continue with 3)
+   Yes
+       Continue with 2)
+   No
+       Continue with 3)
 
-2) Try accessing a page that requires the user to be authenticated. Does it redirect to the two-factor authentication
+#. Try accessing a page that requires the user to be authenticated. Does it redirect to the two-factor authentication
    form?
 
-* Yes:
+   Yes
+       **Solution:** The page you've seen after login doesn't require a fully authenticated user. Most likely that
+       path is accessible to ``IS_AUTHENTICATED_ANONYMOUSLY`` via your security ``access_control`` configuration. Either
+       change your ``access_control`` configuration or after login force-redirect to user to a page that requires full
+       authentication.
+   No
+       Unknown issue. Try to reach out for help by
+       :doc:`creating an issue </https://github.com/scheb/2fa/issues/new?labels=Support&template=support-request>` and let us
+       know what you've already tested.
 
-  * **Solution:** The page you've seen after login doesn't require a fully authenticated user. Most likely that
-    path is accessible to ``IS_AUTHENTICATED_ANONYMOUSLY`` via your security ``access_control`` configuration. Either
-    change your ``access_control`` configuration or after login force-redirect to user to a page that requires full
-    authentication.
-
-* No -> Unknown issue. Try to reach out for help by
-  :doc:`creating an issue </https://github.com/scheb/2fa/issues/new?labels=Support&template=support-request>` and let us
-  know what you've already tested.
-
-3) On login, do you reach the end (return statement) of method
+#. On login, do you reach the end (return statement) of method
    ``Scheb\TwoFactorBundle\Security\Authentication\Provider\AuthenticationProviderDecorator::authenticate()``?
 
-* Yes -> Continue with 4)
-* No -> Something is wrong with the integration of the bundle. Try to reach out for help by
-  :doc:`creating an issue </https://github.com/scheb/2fa/issues/new?labels=Support&template=support-request>` and let us
-  know what you've already tested.
+   Yes
+       Continue with 4)
+   No
+       Something is wrong with the integration of the bundle. Try to reach out for help by
+      :doc:`creating an issue </https://github.com/scheb/2fa/issues/new?labels=Support&template=support-request>` and let us
+      know what you've already tested.
 
-4) On login, is method
+#. On login, is method
    ``Scheb\TwoFactorBundle\Security\TwoFactor\Handler\TwoFactorProviderHandler::getActiveTwoFactorProviders()`` called?
 
-* Yes, it's called -> Continue with 5)
-* No it's not called:
-
-  * **Solution:** Two-factor authentication is skipped, either because of the IP whitelist or because of a trusted
-    device token. IP whitelist is part of the bundle's configuration. Maybe you have whitelisted "localhost" or
-    "127.0.0.1"? The trusted device cookie can be removed with your browser's developer tools.
+   Yes, it's called
+       Continue with 5)
+   No it's not called
+       **Solution:** Two-factor authentication is skipped, either because of the IP whitelist or because of a trusted
+       device token. IP whitelist is part of the bundle's configuration. Maybe you have whitelisted "localhost" or
+       "127.0.0.1"? The trusted device cookie can be removed with your browser's developer tools.
 
 5) Does ``Scheb\TwoFactorBundle\Security\TwoFactor\Handler\TwoFactorProviderHandler::getActiveTwoFactorProviders()``
    return any values?
 
-* Yes, it returns an array of strings -> Unknown issue. Try to reach out for help by
-  :doc:`creating an issue </https://github.com/scheb/2fa/issues/new?labels=Support&template=support-request>` and let us
-  know what you've already tested.
-* No, it returns an empty array:
-
-  * **Solution:** our user doesn't have an active two-factor authentication method. Either the ``is*Enabled`` method
-    returns ``false`` or an essential piece of data (e.g. Google Authenticator secret) is missing.
+   Yes, it returns an array of strings
+       Unknown issue. Try to reach out for help by
+       :doc:`creating an issue </https://github.com/scheb/2fa/issues/new?labels=Support&template=support-request>` and let us
+       know what you've already tested.
+   No, it returns an empty array
+       **Solution:** our user doesn't have an active two-factor authentication method. Either the ``is*Enabled`` method
+       returns ``false`` or an essential piece of data (e.g. Google Authenticator secret) is missing.
 
 Trusted device cookie is not set
 --------------------------------
@@ -283,8 +292,10 @@ Troubleshooting
 Have a look at the response of the HTTP call when you sent over the 2fa and the trusted parameter. Do you see a cookie
 being set (``Set-Cookie`` header)?
 
-* Yes -> Please validate the cookie's parameters. Make sure everything is fine for that cookie: the path, domain, and
-  other cookie options. Did you maybe try to `set it for a top level domain <https://github.com/scheb/two-factor-bundle/issues/242#issuecomment-538735430>`_\ ?
-* No, there's no cookie set: Unknown issue. Try to reach out for help by
-  :doc:`creating an issue </https://github.com/scheb/2fa/issues/new?labels=Support&template=support-request>` and let us
-  know what you've already tested.
+Yes
+    Please validate the cookie's parameters. Make sure everything is fine for that cookie: the path, domain, and
+    other cookie options. Did you maybe try to `set it for a top level domain <https://github.com/scheb/two-factor-bundle/issues/242#issuecomment-538735430>`_\ ?
+No, there's no cookie set
+    Unknown issue. Try to reach out for help by
+    :doc:`creating an issue </https://github.com/scheb/2fa/issues/new?labels=Support&template=support-request>` and let us
+    know what you've already tested.


### PR DESCRIPTION
I quickly scanned all doc files and fixed/improved some reStructuredText syntax. A brief list of the main things:

- reST does not have a strict standard on what characters to use to mark title levels. In [the Symfony docs standards](https://symfony.com/doc/current/contributing/documentation/standards.html#sphinx) we recommend `~` for level 3, I think it reads nicer than `^` (but of course, you are free to not follow the docs standards)
- reST allows you to have "directive" (those warning/tip/caution/info blocks). I've added them wherever I believe that's what you actually want (e.g. you currently used the "i" character for things I think are `.. info::` or `.. tip:``)
- I'm not sure about the ordered list character, but we always use `#.` instead of `1), 2)` etc. in the Symfony docs.
- reST doesn't allow nesting in-line markup (e.g. bold italic or a literal inside a link).
- We support some custom highlighting languages (like `terminal` and `html+twig`). Also, if you show the same example in multiple formats, you can use a  ["configuration block"](https://symfony.com/doc/current/contributing/documentation/format.html#configuration-blocks) to create the tabs in your code example.