### PR TITLE
Add support for `cookie_secure: auto`

### DIFF
--- a/src/bundle/DependencyInjection/Configuration.php
+++ b/src/bundle/DependencyInjection/Configuration.php
@@ -113,7 +113,7 @@ class Configuration implements ConfigurationInterface
                         ->integerNode('lifetime')->defaultValue(60 * 24 * 3600)->min(1)->end()
                         ->booleanNode('extend_lifetime')->defaultFalse()->end()
                         ->scalarNode('cookie_name')->defaultValue('trusted_device')->end()
-                        ->booleanNode('cookie_secure')->defaultFalse()->end()
+                        ->enumNode('cookie_secure')->values([true, false, 'auto'])->defaultValue('auto')->end()
                         ->scalarNode('cookie_domain')->defaultNull()->end()
                         ->scalarNode('cookie_path')->defaultValue('/')->end()
                         ->scalarNode('cookie_same_site')

--- a/src/bundle/DependencyInjection/SchebTwoFactorExtension.php
+++ b/src/bundle/DependencyInjection/SchebTwoFactorExtension.php
@@ -90,7 +90,7 @@ class SchebTwoFactorExtension extends Extension
         $container->setParameter('scheb_two_factor.trusted_device.cookie_name', $config['trusted_device']['cookie_name']);
         $container->setParameter('scheb_two_factor.trusted_device.lifetime', $config['trusted_device']['lifetime']);
         $container->setParameter('scheb_two_factor.trusted_device.extend_lifetime', $config['trusted_device']['extend_lifetime']);
-        $container->setParameter('scheb_two_factor.trusted_device.cookie_secure', $config['trusted_device']['cookie_secure']);
+        $container->setParameter('scheb_two_factor.trusted_device.cookie_secure', 'auto' === $config['trusted_device']['cookie_secure'] ? null : $config['trusted_device']['cookie_secure']);
         $container->setParameter('scheb_two_factor.trusted_device.cookie_same_site', $config['trusted_device']['cookie_same_site']);
         $container->setParameter('scheb_two_factor.trusted_device.cookie_domain', $config['trusted_device']['cookie_domain']);
         $container->setParameter('scheb_two_factor.trusted_device.cookie_path', $config['trusted_device']['cookie_path']);

--- a/src/trusted-device/Security/TwoFactor/Trusted/TrustedCookieResponseListener.php
+++ b/src/trusted-device/Security/TwoFactor/Trusted/TrustedCookieResponseListener.php
@@ -30,7 +30,7 @@ class TrustedCookieResponseListener implements EventSubscriberInterface
     private $cookieName;
 
     /**
-     * @var bool
+     * @var bool|null
      */
     private $cookieSecure;
 
@@ -53,7 +53,7 @@ class TrustedCookieResponseListener implements EventSubscriberInterface
         TrustedDeviceTokenStorage $trustedTokenStorage,
         int $trustedTokenLifetime,
         string $cookieName,
-        bool $cookieSecure,
+        ?bool $cookieSecure,
         ?string $cookieSameSite,
         ?string $cookiePath,
         ?string $cookieDomain
@@ -88,7 +88,7 @@ class TrustedCookieResponseListener implements EventSubscriberInterface
                 $this->getValidUntil(),
                 $this->cookiePath,
                 $domain,
-                $this->cookieSecure,
+                null === $this->cookieSecure ? $event->getRequest()->isSecure() : $this->cookieSecure,
                 true,
                 false,
                 $this->cookieSameSite


### PR DESCRIPTION
**Description**

This adds support for `cookie_secure: auto`. Symfony supports this value for the session and remember me cookies. It enables setting the secure flag only when the request was secure. This makes it very easy to have the most secure configuration that works in production (secure) and locally (not-secure).