### PR TITLE
Fix deprecation warnings

### DIFF
--- a/src/bundle/Security/TwoFactor/Event/AuthenticationSuccessEventSuppressor.php
+++ b/src/bundle/Security/TwoFactor/Event/AuthenticationSuccessEventSuppressor.php
@@ -34,7 +34,7 @@ class AuthenticationSuccessEventSuppressor implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             AuthenticationEvents::AUTHENTICATION_SUCCESS => ['onLogin', self::LISTENER_PRIORITY],

--- a/src/trusted-device/Security/TwoFactor/Trusted/TrustedCookieResponseListener.php
+++ b/src/trusted-device/Security/TwoFactor/Trusted/TrustedCookieResponseListener.php
@@ -85,7 +85,7 @@ class TrustedCookieResponseListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [KernelEvents::RESPONSE => 'onKernelResponse'];
     }


### PR DESCRIPTION
As Symfony now warns for return types that may be added in the future.. It'd be good to add these.

i.e. I got this in my test output:

```
  1x: Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Scheb\TwoFactorBundle\Security\TwoFactor\Event\AuthenticationSuccessEventSuppressor" now to avoid errors or add an explicit @return annotation to suppress this message.

  1x: Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Scheb\TwoFactorBundle\Security\TwoFactor\Trusted\TrustedCookieResponseListener" now to avoid errors or add an explicit @return annotation to suppress this message.
```

There may be other places that need fixing, sorry if it's not complete.