### PR TITLE
Fix variable name

### DIFF
--- a/src/bundle/DependencyInjection/Factory/Security/TwoFactorServicesFactory.php
+++ b/src/bundle/DependencyInjection/Factory/Security/TwoFactorServicesFactory.php
@@ -58,12 +58,12 @@ class TwoFactorServicesFactory
             return $config['authentication_required_handler'];
         }
 
-        $successHandlerId = TwoFactorFactory::AUTHENTICATION_REQUIRED_HANDLER_ID_PREFIX.$firewallName;
+        $authenticationRequiredHandlerId = TwoFactorFactory::AUTHENTICATION_REQUIRED_HANDLER_ID_PREFIX.$firewallName;
         $container
-            ->setDefinition($successHandlerId, new ChildDefinition(TwoFactorFactory::AUTHENTICATION_REQUIRED_HANDLER_DEFINITION_ID))
+            ->setDefinition($authenticationRequiredHandlerId, new ChildDefinition(TwoFactorFactory::AUTHENTICATION_REQUIRED_HANDLER_DEFINITION_ID))
             ->replaceArgument(1, new Reference($twoFactorFirewallConfigId));
 
-        return $successHandlerId;
+        return $authenticationRequiredHandlerId;
     }
 
     /**


### PR DESCRIPTION
**Description**
Fixes a minor typo / wrong variable naming.

Should this go into 5.x as well? 
