### PR TITLE
[Doc] Fix some links and references

### DIFF
--- a/doc/providers/google.rst
+++ b/doc/providers/google.rst
@@ -3,14 +3,14 @@ Google Authenticator
 
 `Google Authenticator <https://en.wikipedia.org/wiki/Google_Authenticator>`_ is a popular implementation of a
 `TOTP algorithm <https://en.wikipedia.org/wiki/Time-based_One-Time_Password>`_ to generate authentication codes.
-Compared to the :doc:`TOTP two-factor provider </totp>`, the implementation has a fixed configuration, which is
+Compared to the :doc:`TOTP two-factor provider </providers/totp>`, the implementation has a fixed configuration, which is
 necessary to be compatible with the Google Authenticator app:
 
 * it generates 6-digit codes
 * the code changes every 30 seconds
 * It uses the sha1 hashing algorithm
 
-If you need different settings, please use the :doc:`TOTP two-factor provider </totp>`. Be warned that custom TOTP
+If you need different settings, please use the :doc:`TOTP two-factor provider </providers/totp>`. Be warned that custom TOTP
 configurations likely won't be compatible with the Google Authenticator app.
 
 How authentication works
@@ -123,7 +123,7 @@ Custom Form Rendering
 
 There are certain cases when it's not enough to just change the template. For example, you're using two-factor
 authentication on multiple firewalls and you need to
-:doc:`render the form differently for each firewall </../firewall_template>`. In such a case you can implement a form
+:doc:`render the form differently for each firewall </firewall_template>`. In such a case you can implement a form
 renderer to fully customize the rendering logic.
 
 Create a class implementing ``Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorFormRendererInterface``:

--- a/doc/providers/totp.rst
+++ b/doc/providers/totp.rst
@@ -2,7 +2,7 @@ TOTP Authentication
 ===================
 
 TOTP authentication uses the `TOTP algorithm <https://en.wikipedia.org/wiki/Time-based_One-Time_Password>`_ to generate
-authentication codes. Compared to :doc:`Google Authenticator two-factor provider </google>`, the TOTP two-factor
+authentication codes. Compared to :doc:`Google Authenticator two-factor provider </providers/google>`, the TOTP two-factor
 provider offers more configuration options, but that means your configuration isn't necessarily compatible with the
 `Google Authenticator app <https://github.com/google/google-authenticator/wiki>`_.
 

--- a/doc/troubleshooting.rst
+++ b/doc/troubleshooting.rst
@@ -124,8 +124,7 @@ Troubleshooting
 
    No
        Unknown issue. Try to reach out for help by
-       :doc:`creating an issue </https://github.com/scheb/2fa/issues/new?labels=Support&template=support-request>` and
-       let us know what you've already tested.
+       `creating an issue`_ and let us know what you've already tested.
 
 **Solution to: Your authenticated token was flagged as invalid**
 
@@ -232,8 +231,7 @@ Troubleshooting
 
    No
        Unknown issue. Try to reach out for help by
-       :doc:`creating an issue </https://github.com/scheb/2fa/issues/new?labels=Support&template=support-request>` and let us
-       know what you've already tested.
+       `creating an issue`_ and let us know what you've already tested.
 
 #. On login, do you reach the end (return statement) of method
    ``Scheb\TwoFactorBundle\Security\Authentication\Provider\AuthenticationProviderDecorator::authenticate()``?
@@ -243,8 +241,7 @@ Troubleshooting
 
    No
        Something is wrong with the integration of the bundle. Try to reach out for help by
-      :doc:`creating an issue </https://github.com/scheb/2fa/issues/new?labels=Support&template=support-request>` and let us
-      know what you've already tested.
+      `creating an issue`_ and let us know what you've already tested.
 
 #. On login, is method
    ``Scheb\TwoFactorBundle\Security\TwoFactor\Handler\TwoFactorProviderHandler::getActiveTwoFactorProviders()`` called?
@@ -262,8 +259,7 @@ Troubleshooting
 
    Yes, it returns an array of strings
        Unknown issue. Try to reach out for help by
-       :doc:`creating an issue </https://github.com/scheb/2fa/issues/new?labels=Support&template=support-request>` and let us
-       know what you've already tested.
+       `creating an issue`_ and let us know what you've already tested.
 
    No, it returns an empty array
        **Solution:** our user doesn't have an active two-factor authentication method. Either the ``is*Enabled`` method
@@ -298,5 +294,6 @@ Yes
 
 No, there's no cookie set
     Unknown issue. Try to reach out for help by
-    :doc:`creating an issue </https://github.com/scheb/2fa/issues/new?labels=Support&template=support-request>` and let us
-    know what you've already tested.
+    `creating an issue`_ and let us know what you've already tested.
+
+.. _`creating an issue`: https://github.com/scheb/2fa/issues/new?labels=Support&template=support-request


### PR DESCRIPTION
It fixes the following errors reported by Symfony Docs builder:

```
Errors for SchebTwoFactorBundle / 5.x

Build errors from "2022-05-02 01:21:26"

Found invalid reference "/google" in file "providers/totp"
Found invalid reference "/google" in file "providers/totp"
Found invalid reference "/totp" in file "providers/google"
Found invalid reference "/totp" in file "providers/google"
Found invalid reference "/totp" in file "providers/google"
Found invalid reference "/totp" in file "providers/google"
Found invalid reference "/../firewall_template" in file "providers/google"
Found invalid reference "/../firewall_template" in file "providers/google"
Found invalid reference "/https://github.com/scheb/2fa/issues/new?labels=Support&template=support-request" in file "troubleshooting"
Found invalid reference "/https://github.com/scheb/2fa/issues/new?labels=Support&template=support-request" in file "troubleshooting"
Found invalid reference "/https://github.com/scheb/2fa/issues/new?labels=Support&template=support-request" in file "troubleshooting"
Found invalid reference "/https://github.com/scheb/2fa/issues/new?labels=Support&template=support-request" in file "troubleshooting"
Found invalid reference "/https://github.com/scheb/2fa/issues/new?labels=Support&template=support-request" in file "troubleshooting"
Found invalid reference "/https://github.com/scheb/2fa/issues/new?labels=Support&template=support-request" in file "troubleshooting"
Found invalid reference "/https://github.com/scheb/2fa/issues/new?labels=Support&template=support-request" in file "troubleshooting"
Found invalid reference "/https://github.com/scheb/2fa/issues/new?labels=Support&template=support-request" in file "troubleshooting"
```