### PR TITLE
Allow to use symfony mailer default configuration

### DIFF
--- a/src/bundle/DependencyInjection/Configuration.php
+++ b/src/bundle/DependencyInjection/Configuration.php
@@ -144,7 +144,7 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('mailer')->defaultNull()->end()
                         ->scalarNode('code_generator')->defaultValue('scheb_two_factor.security.email.default_code_generator')->end()
                         ->scalarNode('form_renderer')->defaultNull()->end()
-                        ->scalarNode('sender_email')->defaultValue('no-reply@example.com')->end()
+                        ->scalarNode('sender_email')->defaultNull()->end()
                         ->scalarNode('sender_name')->defaultNull()->end()
                         ->scalarNode('template')->defaultValue('@SchebTwoFactor/Authentication/form.html.twig')->end()
                         ->integerNode('digits')->defaultValue(4)->min(1)->end()

--- a/src/email/Mailer/SymfonyAuthCodeMailer.php
+++ b/src/email/Mailer/SymfonyAuthCodeMailer.php
@@ -14,16 +14,16 @@ use Symfony\Component\Mime\Email;
  */
 class SymfonyAuthCodeMailer implements AuthCodeMailerInterface
 {
-    private Address|string $senderAddress;
+    private Address|string|null $senderAddress = null;
 
     public function __construct(
         private MailerInterface $mailer,
-        string $senderEmail,
+        ?string $senderEmail,
         ?string $senderName,
     ) {
         if (null !== $senderName) {
             $this->senderAddress = new Address($senderEmail, $senderName);
-        } else {
+        } elseif ($senderEmail) {
             $this->senderAddress = $senderEmail;
         }
     }
@@ -38,9 +38,13 @@ class SymfonyAuthCodeMailer implements AuthCodeMailerInterface
         $message = new Email();
         $message
             ->to($user->getEmailAuthRecipient())
-            ->from($this->senderAddress)
             ->subject('Authentication Code')
             ->text($authCode);
+
+        if (null !== $this->senderAddress) {
+            $message->from($this->senderAddress);
+        }
+
         $this->mailer->send($message);
     }
 }

--- a/src/email/Mailer/SymfonyAuthCodeMailer.php
+++ b/src/email/Mailer/SymfonyAuthCodeMailer.php
@@ -21,7 +21,7 @@ class SymfonyAuthCodeMailer implements AuthCodeMailerInterface
         ?string $senderEmail,
         ?string $senderName,
     ) {
-        if (null !== $senderName) {
+        if (null !== $senderEmail && null !== $senderName) {
             $this->senderAddress = new Address($senderEmail, $senderName);
         } elseif ($senderEmail) {
             $this->senderAddress = $senderEmail;

--- a/tests/Mailer/SymfonyAuthCodeMailerTest.php
+++ b/tests/Mailer/SymfonyAuthCodeMailerTest.php
@@ -28,6 +28,42 @@ class SymfonyAuthCodeMailerTest extends TestCase
      */
     public function sendAuthCode_hasAuthCode_sendEmail(): void
     {
+        // Stub the user object
+        $user = $this->createMock(TwoFactorInterface::class);
+        $user
+            ->expects($this->any())
+            ->method('getEmailAuthRecipient')
+            ->willReturn('recipient@example.com');
+        $user
+            ->expects($this->any())
+            ->method('getEmailAuthCode')
+            ->willReturn('1234');
+
+        $messageValidator = function ($mail) {
+            /** @var Email $mail */
+            $this->assertInstanceOf(Email::class, $mail);
+            $this->assertEquals('recipient@example.com', current($mail->getTo())->getAddress());
+            $this->assertEquals('sender@example.com', current($mail->getFrom())->getAddress());
+            $this->assertEquals('Authentication Code', $mail->getSubject());
+            $this->assertEquals('1234', $mail->getBody()->bodyToString());
+
+            return true;
+        };
+
+        // Expect mail to be sent
+        $this->symfonyMailer
+            ->expects($this->once())
+            ->method('send')
+            ->with($this->callback($messageValidator));
+
+        $this->mailer->sendAuthCode($user);
+    }
+
+    /**
+     * @test
+     */
+    public function sendAuthCode_hasAuthCode_sendEmail_withoutSender(): void
+    {
         $mailer = new SymfonyAuthCodeMailer($this->symfonyMailer, null, null);
 
         // Stub the user object
@@ -59,42 +95,6 @@ class SymfonyAuthCodeMailerTest extends TestCase
             ->with($this->callback($messageValidator));
 
         $mailer->sendAuthCode($user);
-    }
-
-    /**
-     * @test
-     */
-    public function sendAuthCode_hasAuthCode_sendEmail_withoutSender(): void
-    {
-        // Stub the user object
-        $user = $this->createMock(TwoFactorInterface::class);
-        $user
-            ->expects($this->any())
-            ->method('getEmailAuthRecipient')
-            ->willReturn('recipient@example.com');
-        $user
-            ->expects($this->any())
-            ->method('getEmailAuthCode')
-            ->willReturn('1234');
-
-        $messageValidator = function ($mail) {
-            /** @var Email $mail */
-            $this->assertInstanceOf(Email::class, $mail);
-            $this->assertEquals('recipient@example.com', current($mail->getTo())->getAddress());
-            $this->assertEquals('sender@example.com', current($mail->getFrom())->getAddress());
-            $this->assertEquals('Authentication Code', $mail->getSubject());
-            $this->assertEquals('1234', $mail->getBody()->bodyToString());
-
-            return true;
-        };
-
-        // Expect mail to be sent
-        $this->symfonyMailer
-            ->expects($this->once())
-            ->method('send')
-            ->with($this->callback($messageValidator));
-
-        $this->mailer->sendAuthCode($user);
     }
 
     /**

--- a/tests/Mailer/SymfonyAuthCodeMailerTest.php
+++ b/tests/Mailer/SymfonyAuthCodeMailerTest.php
@@ -78,6 +78,10 @@ class SymfonyAuthCodeMailerTest extends TestCase
             ->willReturn('1234');
 
         $messageValidator = function ($mail) {
+            // normally set by the mailer in a listener https://github.com/symfony/mailer/blob/8fa150355115ea09238858ae3cfaf249fd1fd5ed/EventListener/EnvelopeListener.php#L49
+            // can be removed when min version is symfony 6.1 where sender is to check the message
+            $mail->sender('no-reply@example.com');
+
             /** @var Email $mail */
             $this->assertInstanceOf(Email::class, $mail);
             $this->assertEquals('recipient@example.com', current($mail->getTo())->getAddress());

--- a/tests/Mailer/SymfonyAuthCodeMailerTest.php
+++ b/tests/Mailer/SymfonyAuthCodeMailerTest.php
@@ -77,13 +77,11 @@ class SymfonyAuthCodeMailerTest extends TestCase
             ->method('getEmailAuthCode')
             ->willReturn('1234');
 
-        $messageValidator = function ($mail) {
+        $messageValidator = function (Email $mail) {
             // normally set by the mailer in a listener https://github.com/symfony/mailer/blob/8fa150355115ea09238858ae3cfaf249fd1fd5ed/EventListener/EnvelopeListener.php#L49
             // can be removed when min version is symfony 6.1 where sender is to check the message
             $mail->sender('no-reply@example.com');
 
-            /** @var Email $mail */
-            $this->assertInstanceOf(Email::class, $mail);
             $this->assertEquals('recipient@example.com', current($mail->getTo())->getAddress());
             $this->assertFalse(current($mail->getFrom()));
             $this->assertEquals('Authentication Code', $mail->getSubject());

--- a/tests/Mailer/SymfonyAuthCodeMailerTest.php
+++ b/tests/Mailer/SymfonyAuthCodeMailerTest.php
@@ -62,7 +62,7 @@ class SymfonyAuthCodeMailerTest extends TestCase
     /**
      * @test
      */
-    public function sendAuthCode_hasAuthCode_sendEmail_withoutSender(): void
+    public function sendAuthCode_hasAuthCode_sendEmailWithoutSender(): void
     {
         $mailer = new SymfonyAuthCodeMailer($this->symfonyMailer, null, null);
 
@@ -81,7 +81,7 @@ class SymfonyAuthCodeMailerTest extends TestCase
             /** @var Email $mail */
             $this->assertInstanceOf(Email::class, $mail);
             $this->assertEquals('recipient@example.com', current($mail->getTo())->getAddress());
-            $this->assertNull(current($mail->getFrom()));
+            $this->assertFalse(current($mail->getFrom()));
             $this->assertEquals('Authentication Code', $mail->getSubject());
             $this->assertEquals('1234', $mail->getBody()->bodyToString());
 


### PR DESCRIPTION
<!--
👍🎉 First off, thanks for taking the time to contribute! 🎉👍

Here are some tips for you:
 - Please follow the PR contribution guidelines: https://github.com/scheb/2fa/blob/6.x/CONTRIBUTING.md#creating-a-pull-request
 - Don't break backwards compatibility. If you have to, let's discuss! :)
 - Always add/update tests and ensure the build passes
-->

**Description**

The symfony/mailer allows already defining a default sender. Currently the scheb/2fa is not using it and use `no-reply@example.com` which can make issues if somebody is not changing it in there project. By defaulting to the `mailer` configuration it is less forgotten.

Symfony docs reference: https://symfony.com/doc/current/mailer.html#mailer-configure-email-globally