### PR TITLE
Support spomky-labs/otphp v11

### DIFF
--- a/app/composer.json
+++ b/app/composer.json
@@ -10,7 +10,7 @@
         "endroid/qr-code": "^4.0",
         "lcobucci/jwt": "^4.0",
         "paragonie/constant_time_encoding": "^2.4",
-        "spomky-labs/otphp": "^10.0",
+        "spomky-labs/otphp": "^10.0 || ^11.0",
         "symfony/dotenv": "^5.4 || ^6.0",
         "symfony/mailer": "^5.4 || ^6.0",
         "symfony/monolog-bundle": "^3.1",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "ext-json": "*",
         "lcobucci/jwt": "^4.0",
         "paragonie/constant_time_encoding": "^2.4",
-        "spomky-labs/otphp": "^10.0",
+        "spomky-labs/otphp": "^10.0 || ^11.0",
         "symfony/config": "^5.4 || ^6.0",
         "symfony/dependency-injection": "^5.4 || ^6.0",
         "symfony/event-dispatcher": "^5.4 || ^6.0",

--- a/src/google-authenticator/composer.json
+++ b/src/google-authenticator/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": "~8.0.0 || ~8.1.0",
         "scheb/2fa-bundle": "self.version",
-        "spomky-labs/otphp": "^10.0",
+        "spomky-labs/otphp": "^10.0 || ^11.0",
         "paragonie/constant_time_encoding": "^2.4"
     },
     "autoload": {

--- a/src/totp/composer.json
+++ b/src/totp/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": "~8.0.0 || ~8.1.0",
         "scheb/2fa-bundle": "self.version",
-        "spomky-labs/otphp": "^10.0",
+        "spomky-labs/otphp": "^10.0 || ^11.0",
         "paragonie/constant_time_encoding": "^2.4"
     },
     "autoload": {


### PR DESCRIPTION
**Description**

Allows installing `spomky-labs/otphp` v11 (see changelog here: https://github.com/Spomky-Labs/otphp/releases/tag/v11.0.0).

Tests passing on my fork's Actions: https://github.com/IonBazan/2fa/actions/runs/2773436673