### PR TITLE
Configure JWT library via dependency injection

### DIFF
--- a/app/config/services.yaml
+++ b/app/config/services.yaml
@@ -26,3 +26,9 @@ services:
 
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones
+
+    scheb_two_factor.trusted_jwt_encoder.configuration.key:
+        class: Lcobucci\JWT\Signer\Key\InMemory
+        factory: [Lcobucci\JWT\Signer\Key\InMemory, 'base64Encoded']
+        arguments:
+            - oW2+MyKdgOf+iS1+qqgqb0FK5+1oZjDYGBemymEuzgU=

--- a/src/trusted-device/Security/TwoFactor/Trusted/JwtTokenEncoder.php
+++ b/src/trusted-device/Security/TwoFactor/Trusted/JwtTokenEncoder.php
@@ -9,8 +9,6 @@ use Lcobucci\Clock\Clock;
 use Lcobucci\Clock\SystemClock;
 use Lcobucci\JWT\Configuration;
 use Lcobucci\JWT\Exception;
-use Lcobucci\JWT\Signer\Hmac\Sha256;
-use Lcobucci\JWT\Signer\Key\InMemory;
 use Lcobucci\JWT\Token\Plain;
 use Lcobucci\JWT\Validation\Constraint;
 
@@ -25,12 +23,10 @@ class JwtTokenEncoder
     public const CLAIM_FIREWALL = 'fwl';
     public const CLAIM_VERSION = 'vsn';
 
-    private Configuration $configuration;
     private Clock $clock;
 
-    public function __construct(string $applicationSecret, ?Clock $clock = null)
+    public function __construct(private Configuration $configuration, ?Clock $clock = null)
     {
-        $this->configuration = Configuration::forSymmetricSigner(new Sha256(), InMemory::plainText($applicationSecret));
         $this->clock = $clock ?? SystemClock::fromSystemTimezone();
     }
 

--- a/src/trusted-device/Security/TwoFactor/Trusted/JwtTokenEncoder.php
+++ b/src/trusted-device/Security/TwoFactor/Trusted/JwtTokenEncoder.php
@@ -46,10 +46,10 @@ class JwtTokenEncoder
         return $builder->getToken($this->configuration->signer(), $this->configuration->signingKey());
     }
 
-    public function decodeToken(string $token): ?Plain
+    public function decodeToken(string $encodedToken): ?Plain
     {
         try {
-            $token = $this->configuration->parser()->parse($token);
+            $token = $this->configuration->parser()->parse($encodedToken);
         } catch (Exception) {
             return null; // Could not decode token
         }

--- a/src/trusted-device/Security/TwoFactor/Trusted/JwtTokenEncoder.php
+++ b/src/trusted-device/Security/TwoFactor/Trusted/JwtTokenEncoder.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Scheb\TwoFactorBundle\Security\TwoFactor\Trusted;
 
 use DateTimeImmutable;
+use Lcobucci\Clock\Clock;
+use Lcobucci\Clock\SystemClock;
 use Lcobucci\JWT\Configuration;
 use Lcobucci\JWT\Exception;
 use Lcobucci\JWT\Signer\Hmac\Sha256;
 use Lcobucci\JWT\Signer\Key\InMemory;
 use Lcobucci\JWT\Token\Plain;
-use Lcobucci\JWT\Validation\Constraint\SignedWith;
+use Lcobucci\JWT\Validation\Constraint;
 
 /**
  * @internal
@@ -24,17 +26,18 @@ class JwtTokenEncoder
     public const CLAIM_VERSION = 'vsn';
 
     private Configuration $configuration;
+    private Clock $clock;
 
-    public function __construct(string $applicationSecret)
+    public function __construct(string $applicationSecret, ?Clock $clock = null)
     {
         $this->configuration = Configuration::forSymmetricSigner(new Sha256(), InMemory::plainText($applicationSecret));
-        $this->configuration->setValidationConstraints(new SignedWith($this->configuration->signer(), $this->configuration->signingKey()));
+        $this->clock = $clock ?? SystemClock::fromSystemTimezone();
     }
 
     public function generateToken(string $username, string $firewallName, int $version, DateTimeImmutable $validUntil): Plain
     {
         $builder = $this->configuration->builder()
-            ->issuedAt(new DateTimeImmutable())
+            ->issuedAt($this->clock->now())
             ->expiresAt($validUntil)
             ->withClaim(self::CLAIM_USERNAME, $username)
             ->withClaim(self::CLAIM_FIREWALL, $firewallName)
@@ -55,14 +58,18 @@ class JwtTokenEncoder
             return null;
         }
 
-        if (!$this->configuration->validator()->validate($token, ...$this->configuration->validationConstraints())) {
-            return null;
-        }
-
-        if ($token->isExpired(new DateTimeImmutable())) {
+        if (!$this->configuration->validator()->validate($token, ...$this->validationConstraints())) {
             return null;
         }
 
         return $token;
+    }
+
+    /** @return iterable<int, Constraint> */
+    private function validationConstraints(): iterable
+    {
+        yield new Constraint\SignedWith($this->configuration->signer(), $this->configuration->signingKey());
+        yield new Constraint\ValidAt($this->clock); // replace with LooseValidAt once dependency on lcobucci/jwt is bumped up
+        yield from $this->configuration->validationConstraints();
     }
 }

--- a/tests/Security/TwoFactor/Trusted/JwtTokenEncoderTest.php
+++ b/tests/Security/TwoFactor/Trusted/JwtTokenEncoderTest.php
@@ -11,6 +11,7 @@ use Lcobucci\JWT\Signer\Key\InMemory;
 use Lcobucci\JWT\Token\Plain;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Trusted\JwtTokenEncoder;
 use Scheb\TwoFactorBundle\Tests\TestCase;
+use function base64_decode;
 use function base64_encode;
 use function sprintf;
 
@@ -18,15 +19,15 @@ class JwtTokenEncoderTest extends TestCase
 {
     private const CLAIM = 'test';
     private const TOKEN_ID = 'tokenId';
-    private const APPLICATION_SECRET = 'applicationSecret';
+    private const APPLICATION_SECRET = 'oW2+MyKdgOf+iS1+qqgqb0FK5+1oZjDYGBemymEuzgU=';
 
     private JwtTokenEncoder $encoder;
     private Configuration $configuration;
 
     protected function setUp(): void
     {
-        $this->encoder = new JwtTokenEncoder(self::APPLICATION_SECRET);
-        $this->configuration = Configuration::forSymmetricSigner(new Sha256(), InMemory::plainText(self::APPLICATION_SECRET));
+        $this->encoder = new JwtTokenEncoder(base64_decode(self::APPLICATION_SECRET));
+        $this->configuration = Configuration::forSymmetricSigner(new Sha256(), InMemory::base64Encoded(self::APPLICATION_SECRET));
     }
 
     protected function createToken(DateTimeImmutable $expirationDate): string
@@ -96,7 +97,7 @@ class JwtTokenEncoderTest extends TestCase
             '%s.%s.%s',
             base64_encode('{"typ":"JWT","alg":"HS256"}'),
             'eyJ0ZXN0IjoidG9rZW5JZCJ9',
-            'LZGo1rmO-iHr5U489XaSC1io7l821fmFSIlOKcZ-c24'
+            'sQft2vmMyZ1kL1FPLN5vsg0akuyMoDMNjP9adFxnYOs'
         );
 
         $this->assertInstanceOf(Plain::class, $this->encoder->decodeToken($encodedToken));
@@ -111,7 +112,7 @@ class JwtTokenEncoderTest extends TestCase
             '%s.%s.%s',
             base64_encode('{"typ":"JWT","alg":"none"}'), // Modified the algorithm from 'HS256' to 'none'
             'eyJ0ZXN0IjoidG9rZW5JZCJ9',
-            'LZGo1rmO-iHr5U489XaSC1io7l821fmFSIlOKcZ-c24'
+            'sQft2vmMyZ1kL1FPLN5vsg0akuyMoDMNjP9adFxnYOs'
         );
 
         $this->assertNull($this->encoder->decodeToken($encodedNoneAlgToken));
@@ -126,7 +127,7 @@ class JwtTokenEncoderTest extends TestCase
             '%s.%s.%s',
             base64_encode('{"typ":"JWT","alg":"test"}'), // Modified the algorithm from 'HS256' to 'test'
             'eyJ0ZXN0IjoidG9rZW5JZCJ9',
-            'LZGo1rmO-iHr5U489XaSC1io7l821fmFSIlOKcZ-c24'
+            'sQft2vmMyZ1kL1FPLN5vsg0akuyMoDMNjP9adFxnYOs'
         );
 
         $this->assertNull($this->encoder->decodeToken($encodedTestAlgToken));

--- a/tests/Security/TwoFactor/Trusted/JwtTokenEncoderTest.php
+++ b/tests/Security/TwoFactor/Trusted/JwtTokenEncoderTest.php
@@ -11,7 +11,6 @@ use Lcobucci\JWT\Signer\Key\InMemory;
 use Lcobucci\JWT\Token\Plain;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Trusted\JwtTokenEncoder;
 use Scheb\TwoFactorBundle\Tests\TestCase;
-use function base64_decode;
 use function base64_encode;
 use function sprintf;
 
@@ -26,8 +25,8 @@ class JwtTokenEncoderTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->encoder = new JwtTokenEncoder(base64_decode(self::APPLICATION_SECRET));
         $this->configuration = Configuration::forSymmetricSigner(new Sha256(), InMemory::base64Encoded(self::APPLICATION_SECRET));
+        $this->encoder = new JwtTokenEncoder($this->configuration);
     }
 
     protected function createToken(DateTimeImmutable $expirationDate): string


### PR DESCRIPTION
**Description**

This addresses https://github.com/scheb/2fa/issues/157 by allowing users to configure the JWT generation process according to their needs. They can override the key, the algorithm, or the whole JWT configuration object without affecting the behaviour of the bundle.
