### PR TITLE
Fix return type in docs

### DIFF
--- a/doc/providers/totp.rst
+++ b/doc/providers/totp.rst
@@ -88,7 +88,7 @@ and the period of the temporary codes.
            return $this->username;
        }
 
-       public function getTotpAuthenticationConfiguration(): TotpConfigurationInterface
+       public function getTotpAuthenticationConfiguration(): ?TotpConfigurationInterface
        {
            // You could persist the other configuration options in the user entity to make it individual per user.
            return new TotpConfiguration($this->totpSecret, TotpConfiguration::ALGORITHM_SHA1, 20, 8);


### PR DESCRIPTION
The TwoFactorInterface has a nullable return type.

```php
<?php

declare(strict_types=1);

namespace Scheb\TwoFactorBundle\Model\Totp;

interface TwoFactorInterface
{
    // ...

    /**
     * Return the configuration for TOTP authentication.
     */
    public function getTotpAuthenticationConfiguration(): ?TotpConfigurationInterface;
}

```

<!--
👍🎉 First off, thanks for taking the time to contribute! 🎉👍

Here are some tips for you:
 - Please follow the PR contribution guidelines: https://github.com/scheb/2fa/blob/6.x/CONTRIBUTING.md#creating-a-pull-request
 - Don't break backwards compatibility. If you have to, let's discuss! :)
 - Always add/update tests and ensure the build passes
-->

**Description**
<!--
Please provide a clear and concise description of the change.

For bug fixes:
 - What problem does the PR solve?
 - If this fixes an open issue, please link the bug ticket

For new features:
 - What's the motivation for this change? What's the problem you're trying to solve?
 - Why do you think it's a good idea to solve it this way?
-->
