### PR TITLE
Add optional ThrottlingListener to throttle two factor attempts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
         "squizlabs/php_codesniffer": "^3.5",
         "symfony/mailer": "^5.4 || ^6.0",
         "symfony/yaml": "^5.4 || ^6.0",
-        "vimeo/psalm": "^4.0"
+        "vimeo/psalm": "^4.0",
+        "symfony/rate-limiter": "^5.4 || ^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/bundle/DependencyInjection/Configuration.php
+++ b/src/bundle/DependencyInjection/Configuration.php
@@ -48,6 +48,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('ip_whitelist_provider')->defaultValue('scheb_two_factor.default_ip_whitelist_provider')->end()
                 ->scalarNode('two_factor_token_factory')->defaultValue('scheb_two_factor.default_token_factory')->end()
                 ->scalarNode('two_factor_condition')->defaultNull()->end()
+                ->scalarNode('rate_limiter')->defaultNull()->end()
             ->end();
 
         /** @psalm-suppress ArgumentTypeCoercion */

--- a/src/bundle/DependencyInjection/SchebTwoFactorExtension.php
+++ b/src/bundle/DependencyInjection/SchebTwoFactorExtension.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Scheb\TwoFactorBundle\DependencyInjection;
 
+use Scheb\TwoFactorBundle\Security\TwoFactor\Event\ThrottlingListener;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
@@ -67,6 +69,13 @@ class SchebTwoFactorExtension extends Extension
         }
 
         $this->configureBackupCodeManager($container, $config);
+
+        if (isset($config['rate_limiter'])) {
+            $container->register('scheb_two_factor.rate_limiter', ThrottlingListener::class)
+                ->setArguments([
+                    '$rateLimiterFactory' => new Reference($config['rate_limiter'])
+                ]);
+        }
     }
 
     /**

--- a/src/bundle/Security/TwoFactor/Event/ThrottlingListener.php
+++ b/src/bundle/Security/TwoFactor/Event/ThrottlingListener.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scheb\TwoFactorBundle\Security\TwoFactor\Event;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+
+final class ThrottlingListener implements EventSubscriberInterface
+{
+    public function __construct(
+        private RateLimiterFactory $rateLimiterFactory
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            TwoFactorAuthenticationEvents::ATTEMPT => 'onTwoFactorAttempt',
+            TwoFactorAuthenticationEvents::SUCCESS => 'onTwoFactorSuccess',
+        ];
+    }
+
+    public function onTwoFactorAttempt(TwoFactorAuthenticationEvent $event): void
+    {
+        $rateLimiter = $this->rateLimiterFactory->create($event->getRequest()->getClientIp());
+
+        if (!$rateLimiter->consume()->isAccepted()) {
+            throw new TooManyRequestsHttpException();
+        }
+    }
+
+    public function onTwoFactorSuccess(TwoFactorAuthenticationEvent $event): void
+    {
+        $rateLimiter = $this->rateLimiterFactory->create($event->getRequest()->getClientIp());
+        $rateLimiter->reset();
+    }
+}


### PR DESCRIPTION
**Description**
We recently had our platform pentested and one of the findings was that two factor codes were able to be brute forced by an attacker. In our case, quite easily in fact, because we are using TOTP with 6 digit codes. I added this listener to our core library, and now all our applications are protected from brute forcing the two factor codes. I thought it might be nice to (optionally) add this to this bundle. Let me know what you think. If you think it's a good idea, I will add a unit test.
