### PR TITLE
Check if the session is started

### DIFF
--- a/src/bundle/Security/TwoFactor/Event/TwoFactorFormListener.php
+++ b/src/bundle/Security/TwoFactor/Event/TwoFactorFormListener.php
@@ -30,10 +30,8 @@ class TwoFactorFormListener implements EventSubscriberInterface
         if (!$request->hasSession()) {
             return;
         }
-        
-        $session = $request->getSession();
 
-        if (!$session->isStarted()) {
+        if (!$this->twoFactorFirewallConfig->isAuthFormRequest($request)) {
             return;
         }
 
@@ -42,12 +40,8 @@ class TwoFactorFormListener implements EventSubscriberInterface
             return;
         }
 
-        if ($this->twoFactorFirewallConfig->isAuthFormRequest($request)) {
-            $event = new TwoFactorAuthenticationEvent($request, $token);
-            $this->eventDispatcher->dispatch($event, TwoFactorAuthenticationEvents::FORM);
-
-            return;
-        }
+        $event = new TwoFactorAuthenticationEvent($request, $token);
+        $this->eventDispatcher->dispatch($event, TwoFactorAuthenticationEvents::FORM);
     }
 
     /**

--- a/src/bundle/Security/TwoFactor/Event/TwoFactorFormListener.php
+++ b/src/bundle/Security/TwoFactor/Event/TwoFactorFormListener.php
@@ -30,6 +30,12 @@ class TwoFactorFormListener implements EventSubscriberInterface
         if (!$request->hasSession()) {
             return;
         }
+        
+        $session = $request->getSession();
+
+        if (!$session->isStarted()) {
+            return;
+        }
 
         $token = $this->tokenStorage->getToken();
         if (!($token instanceof TwoFactorTokenInterface)) {


### PR DESCRIPTION
For bug fixes:
 - Avoid starting session usage

The Symfony Framework currently detects usage on the session. If it is used, Symfony will output private headers. See https://github.com/symfony/symfony/blob/c79d4ab7e787eb27d83581ccb8e15a4e11e88df3/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php#L197

This PR updates the Form listener to check if the session isStarted() before calling getToken on the token storage. Doing so, means the session usage counter isn't incremented.

Alternatively, the check for getToken() should be fired after isAuthFormRequest().

We currently have a site where we're trying to cache the front-end. However, this listener is firing for the front-end firewall even though it isn't relevant.