### PR TITLE
fix getContentType deprecation since symfony 6.2

### DIFF
--- a/src/bundle/Security/Http/Utils/JsonRequestUtils.php
+++ b/src/bundle/Security/Http/Utils/JsonRequestUtils.php
@@ -25,7 +25,7 @@ class JsonRequestUtils
 
     public static function isJsonRequest(Request $request): bool
     {
-        return str_contains((string) $request->getContentType(), 'json');
+        return str_contains((string) (method_exists(Request::class, 'getContentTypeFormat') ? $request->getContentTypeFormat()  : $request->getContentType()), 'json');
     }
 
     /**

--- a/src/bundle/Security/Http/Utils/JsonRequestUtils.php
+++ b/src/bundle/Security/Http/Utils/JsonRequestUtils.php
@@ -12,6 +12,7 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use function is_scalar;
 use function json_decode;
+use function method_exists;
 use function str_contains;
 
 /**

--- a/src/bundle/Security/Http/Utils/JsonRequestUtils.php
+++ b/src/bundle/Security/Http/Utils/JsonRequestUtils.php
@@ -26,7 +26,7 @@ class JsonRequestUtils
 
     public static function isJsonRequest(Request $request): bool
     {
-        return str_contains((string) (method_exists(Request::class, 'getContentTypeFormat') ? $request->getContentTypeFormat()  : $request->getContentType()), 'json');
+        return str_contains((string) (method_exists(Request::class, 'getContentTypeFormat') ? $request->getContentTypeFormat() : $request->getContentType()), 'json');
     }
 
     /**


### PR DESCRIPTION
**Description**
Handle both legacy Request::getContentType() and Request::getContentTypeFormat() introduced with Symfony 6.2
