### PR TITLE
Add subject_email  parameter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
             fail-fast: false
             matrix:
                 php-version:
-                    - '8.1'
+                    - '8.0'
 
         steps:
             -   name: 'Checkout code'

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ composer.lock
 /app/var/
 /app/vendor/
 /app/symfony.lock
+# PHPStorm
+.idea

--- a/app/composer.json
+++ b/app/composer.json
@@ -9,7 +9,7 @@
         "egulias/email-validator": "^3.0",
         "endroid/qr-code": "^4.0",
         "lcobucci/clock": "^2.0 || ^3.0",
-        "lcobucci/jwt": "^4.1",
+        "lcobucci/jwt": "^4.1 || ^5.0",
         "paragonie/constant_time_encoding": "^2.4",
         "spomky-labs/otphp": "^10.0 || ^11.0",
         "symfony/dotenv": "^5.4 || ^6.0",

--- a/app/config/packages/scheb_2fa.yaml
+++ b/app/config/packages/scheb_2fa.yaml
@@ -18,6 +18,7 @@ scheb_two_factor:
         enabled: true                  # If email authentication should be enabled, default false
         sender_email: me@example.com   # Sender email address
         sender_name: John Doe          # Sender name
+        subject_email: Authentication Code # Email subject
         digits: 4                      # Number of digits in authentication code
         template: security/2fa.html.twig   # Template used to render the authentication form
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
         "ext-json": "*",
         "lcobucci/clock": "^2.0 || ^3.0",
-        "lcobucci/jwt": "^4.1",
+        "lcobucci/jwt": "^4.1 || ^5.0",
         "paragonie/constant_time_encoding": "^2.4",
         "spomky-labs/otphp": "^10.0 || ^11.0",
         "symfony/config": "^5.4 || ^6.0",

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -37,6 +37,7 @@ Bundle Configuration
            code_generator: acme.custom_code_generator_service  # Use alternative service to generate authentication code
            sender_email: me@example.com   # Sender email address
            sender_name: John Doe          # Sender name
+           subject_email: Authentication Code # Email subject
            digits: 4                      # Number of digits in authentication code
            template: security/2fa_form.html.twig   # Template used to render the authentication form
            form_renderer: acme.custom_form_renderer  # Use a custom form renderer service

--- a/doc/providers/email.rst
+++ b/doc/providers/email.rst
@@ -49,6 +49,7 @@ To enable this authentication method add this to your configuration:
            enabled: true
            sender_email: no-reply@example.com
            sender_name: John Doe  # Optional
+           subject_email: Authentication Code # Email subject
 
 Your user entity has to implement ``Scheb\TwoFactorBundle\Model\Email\TwoFactorInterface``. The authentication code must
 be persisted, so make sure that it is stored in a persisted field.
@@ -162,6 +163,7 @@ Configuration Reference
            code_generator: acme.custom_code_generator_service  # Use alternative service to generate authentication code
            sender_email: me@example.com   # Sender email address
            sender_name: John Doe          # Sender name
+           subject_email: Authentication Code # Email subject
            digits: 4                      # Number of digits in authentication code
            template: security/2fa_form.html.twig   # Template used to render the authentication form
 

--- a/src/bundle/DependencyInjection/Configuration.php
+++ b/src/bundle/DependencyInjection/Configuration.php
@@ -147,6 +147,7 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('form_renderer')->defaultNull()->end()
                         ->scalarNode('sender_email')->defaultNull()->end()
                         ->scalarNode('sender_name')->defaultNull()->end()
+                        ->scalarNode('subject_email')->defaultNull()->end()
                         ->scalarNode('template')->defaultValue('@SchebTwoFactor/Authentication/form.html.twig')->end()
                         ->integerNode('digits')->defaultValue(4)->min(1)->end()
                     ->end()

--- a/src/bundle/DependencyInjection/SchebTwoFactorExtension.php
+++ b/src/bundle/DependencyInjection/SchebTwoFactorExtension.php
@@ -168,6 +168,7 @@ class SchebTwoFactorExtension extends Extension
 
         $container->setParameter('scheb_two_factor.email.sender_email', $config['email']['sender_email']);
         $container->setParameter('scheb_two_factor.email.sender_name', $config['email']['sender_name']);
+        $container->setParameter('scheb_two_factor.email.subject_email', $config['email']['subject_email']);
         $container->setParameter('scheb_two_factor.email.template', $config['email']['template']);
         $container->setParameter('scheb_two_factor.email.digits', $config['email']['digits']);
         $container->setAlias('scheb_two_factor.security.email.code_generator', $config['email']['code_generator'])->setPublic(true);

--- a/src/bundle/Resources/config/two_factor_provider_email.php
+++ b/src/bundle/Resources/config/two_factor_provider_email.php
@@ -17,6 +17,7 @@ return static function (ContainerConfigurator $container): void {
                 service('mailer.mailer'),
                 '%scheb_two_factor.email.sender_email%',
                 '%scheb_two_factor.email.sender_name%',
+                '%scheb_two_factor.email.subject_email%',
             ])
 
         ->set('scheb_two_factor.security.email.default_code_generator', CodeGenerator::class)

--- a/src/email/Mailer/SymfonyAuthCodeMailer.php
+++ b/src/email/Mailer/SymfonyAuthCodeMailer.php
@@ -15,17 +15,21 @@ use Symfony\Component\Mime\Email;
 class SymfonyAuthCodeMailer implements AuthCodeMailerInterface
 {
     private Address|string|null $senderAddress = null;
+    private string $subjectEmail;
 
     public function __construct(
         private MailerInterface $mailer,
         ?string $senderEmail,
         ?string $senderName,
+        ?string $subjectEmail
     ) {
         if (null !== $senderEmail && null !== $senderName) {
             $this->senderAddress = new Address($senderEmail, $senderName);
         } elseif ($senderEmail) {
             $this->senderAddress = $senderEmail;
         }
+
+        $this->subjectEmail = $subjectEmail ?? 'Authentication Code';
     }
 
     public function sendAuthCode(TwoFactorInterface $user): void
@@ -38,7 +42,7 @@ class SymfonyAuthCodeMailer implements AuthCodeMailerInterface
         $message = new Email();
         $message
             ->to($user->getEmailAuthRecipient())
-            ->subject('Authentication Code')
+            ->subject($this->subjectEmail)
             ->text($authCode);
 
         if (null !== $this->senderAddress) {

--- a/src/trusted-device/composer.json
+++ b/src/trusted-device/composer.json
@@ -15,7 +15,7 @@
         "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
         "scheb/2fa-bundle": "self.version",
         "lcobucci/clock": "^2.0 || ^3.0",
-        "lcobucci/jwt": "^4.1"
+        "lcobucci/jwt": "^4.1 || ^5.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/DependencyInjection/SchebTwoFactorExtensionTest.php
+++ b/tests/DependencyInjection/SchebTwoFactorExtensionTest.php
@@ -41,6 +41,7 @@ class SchebTwoFactorExtensionTest extends TestCase
         $this->assertHasParameter(false, 'scheb_two_factor.trusted_device.enabled');
         $this->assertHasNotParameter('scheb_two_factor.email.sender_email');
         $this->assertHasNotParameter('scheb_two_factor.email.sender_name');
+        $this->assertHasNotParameter('scheb_two_factor.email.subject_email');
         $this->assertHasNotParameter('scheb_two_factor.email.template');
         $this->assertHasNotParameter('scheb_two_factor.email.digits');
         $this->assertHasNotParameter('scheb_two_factor.google.server_name');
@@ -78,6 +79,7 @@ class SchebTwoFactorExtensionTest extends TestCase
         $this->assertHasParameter('alternative', 'scheb_two_factor.model_manager_name');
         $this->assertHasParameter('me@example.com', 'scheb_two_factor.email.sender_email');
         $this->assertHasParameter('Sender Name', 'scheb_two_factor.email.sender_name');
+        $this->assertHasParameter('Authentication Code', 'scheb_two_factor.email.subject_email');
         $this->assertHasParameter('AcmeTestBundle:Authentication:emailForm.html.twig', 'scheb_two_factor.email.template');
         $this->assertHasParameter(6, 'scheb_two_factor.email.digits');
         $this->assertHasParameter('Server Name Google', 'scheb_two_factor.google.server_name');
@@ -659,6 +661,7 @@ email:
     code_generator: acme_test.code_generator
     sender_email: me@example.com
     sender_name: Sender Name
+    subject_email: Authentication Code
     template: AcmeTestBundle:Authentication:emailForm.html.twig
     form_renderer: acme_test.email_form_renderer
     digits: 6

--- a/tests/Mailer/SymfonyAuthCodeMailerTest.php
+++ b/tests/Mailer/SymfonyAuthCodeMailerTest.php
@@ -20,7 +20,7 @@ class SymfonyAuthCodeMailerTest extends TestCase
     protected function setUp(): void
     {
         $this->symfonyMailer = $this->createMock(MailerInterface::class);
-        $this->mailer = new SymfonyAuthCodeMailer($this->symfonyMailer, 'sender@example.com', 'Sender Name');
+        $this->mailer = new SymfonyAuthCodeMailer($this->symfonyMailer, 'sender@example.com', 'Sender Name', 'Authentication Code');
     }
 
     /**
@@ -64,7 +64,7 @@ class SymfonyAuthCodeMailerTest extends TestCase
      */
     public function sendAuthCode_hasAuthCode_sendEmailWithoutSender(): void
     {
-        $mailer = new SymfonyAuthCodeMailer($this->symfonyMailer, null, null);
+        $mailer = new SymfonyAuthCodeMailer($this->symfonyMailer, null, null, null);
 
         // Stub the user object
         $user = $this->createMock(TwoFactorInterface::class);

--- a/tests/Security/TwoFactor/Trusted/TrustedDeviceTokenEncoderTest.php
+++ b/tests/Security/TwoFactor/Trusted/TrustedDeviceTokenEncoderTest.php
@@ -35,7 +35,7 @@ class TrustedDeviceTokenEncoderTest extends TestCase
             ->expects($this->once())
             ->method('generateToken')
             ->with('username', 'firewallName', 1, new DateTime('2018-01-01 01:00:00'))
-            ->willReturn(new Plain(new DataSet([], ''), new DataSet([], ''), Signature::fromEmptyData()));
+            ->willReturn(new Plain(new DataSet([], ''), new DataSet([], ''), new Signature('', '')));
 
         $token = $this->tokenEncoder->generateToken('username', 'firewallName', 1);
         $this->assertInstanceOf(TrustedDeviceToken::class, $token);
@@ -49,7 +49,7 @@ class TrustedDeviceTokenEncoderTest extends TestCase
         $this->jwtEncoder
             ->expects($this->once())
             ->method('decodeToken')
-            ->willReturn(new Plain(new DataSet([], ''), new DataSet([], ''), Signature::fromEmptyData()));
+            ->willReturn(new Plain(new DataSet([], ''), new DataSet([], ''), new Signature('', '')));
 
         $returnValue = $this->tokenEncoder->decodeToken('validToken');
         $this->assertInstanceOf(TrustedDeviceToken::class, $returnValue);

--- a/tests/Security/TwoFactor/Trusted/TrustedDeviceTokenTest.php
+++ b/tests/Security/TwoFactor/Trusted/TrustedDeviceTokenTest.php
@@ -22,7 +22,7 @@ class TrustedDeviceTokenTest extends TestCase
             JwtTokenEncoder::CLAIM_FIREWALL => 'firewallName',
             JwtTokenEncoder::CLAIM_VERSION => 1,
         ], 'encodedClaims');
-        $jwtToken = new Plain(new DataSet([], 'encodedHeaders'), $claims, Signature::fromEmptyData());
+        $jwtToken = new Plain(new DataSet([], 'encodedHeaders'), $claims, new Signature('', ''));
         $this->trustedToken = new TrustedDeviceToken($jwtToken);
     }
 


### PR DESCRIPTION
This PR brings the possibility to define the subject of the mail sent with the authentication code.
The parameter `subject_email` have been added, with a default value equals to the actual text "Authentication Code"