### PR TITLE
Fix flex doc url in doc installation page

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -19,7 +19,7 @@ Step 1: Install with Composer
 The bundle is organized into sub-repositories, so you can choose the exact feature set you need and keep installed
 dependencies to a minimum.
 
-If you're using `Symfony Flex <https://flex.symfony.com/>`_, use the following command to install the bundle via
+If you're using `Symfony Flex <https://symfony.com/doc/current/quick_tour/flex_recipes.html>`_, use the following command to install the bundle via
 `Composer <https://getcomposer.org>`_:
 
 .. code-block:: terminal


### PR DESCRIPTION
**Description**

This commit fixes a dead link to flex documentation in the bundle documentation installation page.
