### PR TITLE
Improve static analysis

### DIFF
--- a/src/totp/Security/TwoFactor/Provider/Totp/TotpAuthenticatorInterface.php
+++ b/src/totp/Security/TwoFactor/Provider/Totp/TotpAuthenticatorInterface.php
@@ -10,6 +10,8 @@ interface TotpAuthenticatorInterface
 {
     /**
      * Validates the code, which was entered by the user.
+     *
+     * @param non-empty-string $code
      */
     public function checkCode(TwoFactorInterface $user, string $code): bool;
 
@@ -20,6 +22,8 @@ interface TotpAuthenticatorInterface
 
     /**
      * Generate a new secret for TOTP authentication.
+     *
+     * @return non-empty-string
      */
     public function generateSecret(): string;
 }


### PR DESCRIPTION
**Description**
`OTPInterface::verify` expects `$otp` parameter as non-empty-string and also it's `createFromSecret`, `getSecret` and `setSecret` methods contracts are non-empty-string