### PR TITLE
chore: bump version of gitHub actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
 
         steps:
             -   name: 'Checkout code'
-                uses: actions/checkout@v2
+                uses: actions/checkout@v3
 
             -   name: 'Setup Build'
                 uses: ./.github/actions/setup-build
@@ -62,7 +62,7 @@ jobs:
                         symfony-version: '6.*'
         steps:
             -   name: 'Checkout code'
-                uses: actions/checkout@v2
+                uses: actions/checkout@v3
 
             -   name: 'Setup Build'
                 uses: ./.github/actions/setup-build
@@ -99,7 +99,7 @@ jobs:
 
         steps:
             -   name: 'Checkout code'
-                uses: actions/checkout@v2
+                uses: actions/checkout@v3
 
             -   name: 'Setup Build'
                 uses: ./.github/actions/setup-build
@@ -126,7 +126,7 @@ jobs:
 
         steps:
             -   name: 'Checkout code'
-                uses: actions/checkout@v2
+                uses: actions/checkout@v3
 
             -   name: 'Setup Build'
                 uses: ./.github/actions/setup-build
@@ -138,7 +138,7 @@ jobs:
                 run: phpdbg -qrr vendor/bin/phpunit --coverage-clover coverage/clover.xml
 
             -   name: 'Send Coverage to Codecov'
-                uses: codecov/codecov-action@v2
+                uses: codecov/codecov-action@v3
                 with:
                     token: ${{ secrets.CODECOV_TOKEN }}
                     files: coverage/clover.xml

--- a/.github/workflows/split.yaml
+++ b/.github/workflows/split.yaml
@@ -13,7 +13,7 @@ jobs:
 
         steps:
             -
-                uses: actions/checkout@v2
+                uses: actions/checkout@v3
                 with:
                     fetch-depth: 0  # Fetch all history
                     ref: "6.x" # Force checkout the branch to split its commits as well


### PR DESCRIPTION
Will fix the ci warnings of deprecated github action versions.
Example: https://github.com/scheb/2fa/actions/runs/5026930219

codecov should be tested. As it will only work in this repo.