### PR TITLE
Add ThrottlingListener to allow MFA attempt throttling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
         "squizlabs/php_codesniffer": "^3.5",
         "symfony/mailer": "^6.4 || ^7.0",
         "symfony/yaml": "^6.4 || ^7.0",
-        "vimeo/psalm": "^5.0"
+        "vimeo/psalm": "^5.0",
+        "symfony/rate-limiter": "^6.4 || ^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/bundle/DependencyInjection/Configuration.php
+++ b/src/bundle/DependencyInjection/Configuration.php
@@ -48,6 +48,13 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('ip_whitelist_provider')->defaultValue('scheb_two_factor.default_ip_whitelist_provider')->end()
                 ->scalarNode('two_factor_token_factory')->defaultValue('scheb_two_factor.default_token_factory')->end()
                 ->scalarNode('two_factor_condition')->defaultNull()->end()
+                ->arrayNode('rate_limiter')
+                    ->canBeEnabled()
+                    ->children()
+                    ->integerNode('max_attempts')->defaultValue(5)->end()
+                    ->scalarNode('interval')->defaultValue('1 minute')->end()
+                    ->scalarNode('lock_factory')->info('The service ID of the lock factory used by the MFA rate limiter (or null to disable locking)')->defaultNull()->end()
+                ->end()
             ->end();
 
         /** @psalm-suppress ArgumentTypeCoercion */

--- a/src/bundle/Security/TwoFactor/Event/ThrottlingListener.php
+++ b/src/bundle/Security/TwoFactor/Event/ThrottlingListener.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scheb\TwoFactorBundle\Security\TwoFactor\Event;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RateLimiter\RequestRateLimiterInterface;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+
+/**
+ * @final
+ */
+class ThrottlingListener implements EventSubscriberInterface
+{
+    public function __construct(
+        private RequestRateLimiterInterface $requestRateLimiter,
+    ) {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            TwoFactorAuthenticationEvents::ATTEMPT => 'onTwoFactorAttempt',
+            TwoFactorAuthenticationEvents::SUCCESS => 'onTwoFactorSuccess',
+        ];
+    }
+
+    public function onTwoFactorAttempt(TwoFactorAuthenticationEvent $event): void
+    {
+        if (!$this->requestRateLimiter->consume($event->getRequest())->isAccepted()) {
+            throw new TooManyRequestsHttpException();
+        }
+    }
+
+    public function onTwoFactorSuccess(TwoFactorAuthenticationEvent $event): void
+    {
+        $this->requestRateLimiter->reset($event->getRequest());
+    }
+}


### PR DESCRIPTION
Trying again after I forgot about #165 :smile: 

Still in draft, because I'm still working on tests, but I thought I would already put something up because of #SymfonyHackday

This basically does the same thing as the previous PR, with one notable improvement. I agree with the point that @hdk-pd made previously (https://github.com/scheb/2fa/pull/165#issuecomment-1376546058). Therefore I took some inspiration from https://github.com/symfony/symfony/pull/38308 and implemented a combined ratelimiter instead of a single one. It will now ratelimit on both IP and user identifier.