### PR TITLE
Add expiring email codes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "egulias/email-validator": "^4.0",
         "phpunit/phpunit": "^10.1",
         "psr/container": ">=1.1",
+        "psr/clock": "^1.0",
         "squizlabs/php_codesniffer": "^3.5",
         "symfony/mailer": "^6.4 || ^7.0",
         "symfony/yaml": "^6.4 || ^7.0",

--- a/doc/providers/email.rst
+++ b/doc/providers/email.rst
@@ -164,6 +164,8 @@ Configuration Reference
            sender_name: John Doe          # Sender name
            digits: 4                      # Number of digits in authentication code
            template: security/2fa_form.html.twig   # Template used to render the authentication form
+           expires_after: PT5M            # Date interval after which the code is considered invalid. NULL disables the expiration.
+           resend_expired: true           # Whether to regenerate an expired code when user submits form
 
 Custom Mailer
 -------------

--- a/src/bundle/DependencyInjection/SchebTwoFactorExtension.php
+++ b/src/bundle/DependencyInjection/SchebTwoFactorExtension.php
@@ -179,6 +179,8 @@ class SchebTwoFactorExtension extends Extension
         $container->setParameter('scheb_two_factor.email.sender_name', $config['email']['sender_name']);
         $container->setParameter('scheb_two_factor.email.template', $config['email']['template']);
         $container->setParameter('scheb_two_factor.email.digits', $config['email']['digits']);
+        $container->setParameter('scheb_two_factor.email.expires_after', $config['email']['expires_after']);
+        $container->setParameter('scheb_two_factor.email.resend_expired', $config['email']['resend_expired']);
         $container->setAlias('scheb_two_factor.security.email.code_generator', $config['email']['code_generator'])->setPublic(true);
 
         if (null !== $config['email']['mailer']) {

--- a/src/bundle/Resources/config/two_factor_provider_email.php
+++ b/src/bundle/Resources/config/two_factor_provider_email.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Psr\Clock\ClockInterface;
 use Scheb\TwoFactorBundle\Mailer\SymfonyAuthCodeMailer;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\DefaultTwoFactorFormRenderer;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\Email\EmailTwoFactorProvider;
@@ -25,6 +26,8 @@ return static function (ContainerConfigurator $container): void {
                 service('scheb_two_factor.persister'),
                 service('scheb_two_factor.security.email.auth_code_mailer'),
                 '%scheb_two_factor.email.digits%',
+                '%scheb_two_factor.email.expires_after%',
+                service(ClockInterface::class)->nullOnInvalid(),
             ])
 
         ->set('scheb_two_factor.security.email.default_form_renderer', DefaultTwoFactorFormRenderer::class)
@@ -39,6 +42,7 @@ return static function (ContainerConfigurator $container): void {
             ->args([
                 service('scheb_two_factor.security.email.code_generator'),
                 service('scheb_two_factor.security.email.form_renderer'),
+                '%scheb_two_factor.email.resend_expired%',
             ])
 
         ->alias(CodeGeneratorInterface::class, 'scheb_two_factor.security.email.code_generator')

--- a/src/email/Model/Email/TwoFactorInterface.php
+++ b/src/email/Model/Email/TwoFactorInterface.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace Scheb\TwoFactorBundle\Model\Email;
 
+use DateTimeImmutable;
+
+/**
+ * @method DateTimeImmutable|null getEmailAuthCodeCreatedAt()
+ * @method void                    setEmailAuthCodeCreatedAt(DateTimeImmutable|null $createdAt)
+ */
 interface TwoFactorInterface
 {
     /**

--- a/src/email/Security/TwoFactor/Provider/Email/EmailTwoFactorProvider.php
+++ b/src/email/Security/TwoFactor/Provider/Email/EmailTwoFactorProvider.php
@@ -20,7 +20,7 @@ class EmailTwoFactorProvider implements TwoFactorProviderInterface
     public function __construct(
         private readonly CodeGeneratorInterface $codeGenerator,
         private readonly TwoFactorFormRendererInterface $formRenderer,
-        private readonly bool $resendExpired
+        private readonly bool $resendExpired,
     ) {
     }
 

--- a/src/email/Security/TwoFactor/Provider/Email/EmailTwoFactorProvider.php
+++ b/src/email/Security/TwoFactor/Provider/Email/EmailTwoFactorProvider.php
@@ -47,8 +47,10 @@ class EmailTwoFactorProvider implements TwoFactorProviderInterface
             return false;
         }
 
-        if ($this->resendExpired && method_exists($this->codeGenerator, 'isCodeExpired') && $this->codeGenerator->isCodeExpired($user)) {
-            $this->codeGenerator->generateAndSend($user);
+        if (method_exists($this->codeGenerator, 'isCodeExpired') && $this->codeGenerator->isCodeExpired($user)) {
+            if ($this->resendExpired) {
+                $this->codeGenerator->generateAndSend($user);
+            }
 
             return false;
         }

--- a/src/email/Security/TwoFactor/Provider/Email/Generator/CodeGenerator.php
+++ b/src/email/Security/TwoFactor/Provider/Email/Generator/CodeGenerator.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace Scheb\TwoFactorBundle\Security\TwoFactor\Provider\Email\Generator;
 
+use DateInterval;
+use DateTimeImmutable;
+use Psr\Clock\ClockInterface;
 use Scheb\TwoFactorBundle\Mailer\AuthCodeMailerInterface;
 use Scheb\TwoFactorBundle\Model\Email\TwoFactorInterface;
 use Scheb\TwoFactorBundle\Model\PersisterInterface;
+use function method_exists;
 use function random_int;
 
 /**
@@ -18,26 +22,62 @@ class CodeGenerator implements CodeGeneratorInterface
         private readonly PersisterInterface $persister,
         private readonly AuthCodeMailerInterface $mailer,
         private readonly int $digits,
+        private readonly string|null $expiresAfter = null,
+        private readonly ClockInterface|null $clock = null,
     ) {
     }
 
     public function generateAndSend(TwoFactorInterface $user): void
     {
-        $min = 10 ** ($this->digits - 1);
-        $max = 10 ** $this->digits - 1;
-        $code = $this->generateCode($min, $max);
-        $user->setEmailAuthCode((string) $code);
+        $user->setEmailAuthCode((string) $this->doGenerateCode());
+
+        if (method_exists($user, 'setEmailAuthCodeCreatedAt')) {
+            $user->setEmailAuthCodeCreatedAt($this->now());
+        }
+
         $this->persister->persist($user);
         $this->mailer->sendAuthCode($user);
     }
 
     public function reSend(TwoFactorInterface $user): void
     {
+        if ($this->isCodeExpired($user) && method_exists($user, 'getEmailAuthCodeCreatedAt') && method_exists($user, 'setEmailAuthCodeCreatedAt')) {
+            $user->setEmailAuthCode((string) $this->doGenerateCode());
+            $user->setEmailAuthCodeCreatedAt($this->now());
+
+            $this->persister->persist($user);
+        }
+
         $this->mailer->sendAuthCode($user);
+    }
+
+    public function isCodeExpired(TwoFactorInterface $user): bool
+    {
+        if (null === $this->expiresAfter || !method_exists($user, 'getEmailAuthCodeCreatedAt') || !method_exists($user, 'setEmailAuthCodeCreatedAt')) {
+            return false;
+        }
+
+        $now = $this->now();
+        $expiresAt = $user->getEmailAuthCodeCreatedAt()?->add(new DateInterval($this->expiresAfter));
+
+        return null !== $expiresAt && $now->getTimestamp() >= $expiresAt->getTimestamp();
     }
 
     protected function generateCode(int $min, int $max): int
     {
         return random_int($min, $max);
+    }
+
+    private function doGenerateCode(): int
+    {
+        $min = 10 ** ($this->digits - 1);
+        $max = 10 ** $this->digits - 1;
+
+        return $this->generateCode($min, $max);
+    }
+
+    private function now(): DateTimeImmutable
+    {
+        return $this->clock?->now() ?? new DateTimeImmutable();
     }
 }

--- a/src/email/Security/TwoFactor/Provider/Email/Generator/CodeGeneratorInterface.php
+++ b/src/email/Security/TwoFactor/Provider/Email/Generator/CodeGeneratorInterface.php
@@ -6,6 +6,9 @@ namespace Scheb\TwoFactorBundle\Security\TwoFactor\Provider\Email\Generator;
 
 use Scheb\TwoFactorBundle\Model\Email\TwoFactorInterface;
 
+/**
+ * @method bool isCodeExpired(TwoFactorInterface $user)
+ */
 interface CodeGeneratorInterface
 {
     /**

--- a/tests/DependencyInjection/SchebTwoFactorExtensionTest.php
+++ b/tests/DependencyInjection/SchebTwoFactorExtensionTest.php
@@ -43,6 +43,8 @@ class SchebTwoFactorExtensionTest extends TestCase
         $this->assertHasNotParameter('scheb_two_factor.email.sender_name');
         $this->assertHasNotParameter('scheb_two_factor.email.template');
         $this->assertHasNotParameter('scheb_two_factor.email.digits');
+        $this->assertHasNotParameter('scheb_two_factor.email.expires_after');
+        $this->assertHasNotParameter('scheb_two_factor.email.resend_expired');
         $this->assertHasNotParameter('scheb_two_factor.google.server_name');
         $this->assertHasNotParameter('scheb_two_factor.google.issuer');
         $this->assertHasNotParameter('scheb_two_factor.google.template');
@@ -80,6 +82,8 @@ class SchebTwoFactorExtensionTest extends TestCase
         $this->assertHasParameter('Sender Name', 'scheb_two_factor.email.sender_name');
         $this->assertHasParameter('AcmeTestBundle:Authentication:emailForm.html.twig', 'scheb_two_factor.email.template');
         $this->assertHasParameter(6, 'scheb_two_factor.email.digits');
+        $this->assertHasParameter('PT15M', 'scheb_two_factor.email.expires_after');
+        $this->assertHasParameter(false, 'scheb_two_factor.email.resend_expired');
         $this->assertHasParameter('Server Name Google', 'scheb_two_factor.google.server_name');
         $this->assertHasParameter('Issuer Google', 'scheb_two_factor.google.issuer');
         $this->assertHasParameter('AcmeTestBundle:Authentication:googleForm.html.twig', 'scheb_two_factor.google.template');
@@ -674,6 +678,8 @@ email:
     template: AcmeTestBundle:Authentication:emailForm.html.twig
     form_renderer: acme_test.email_form_renderer
     digits: 6
+    expires_after: PT15M
+    resend_expired: false
 google:
     enabled: true
     issuer: Issuer Google

--- a/tests/Security/TwoFactor/Provider/Email/EmailTwoFactorProviderTest.php
+++ b/tests/Security/TwoFactor/Provider/Email/EmailTwoFactorProviderTest.php
@@ -196,8 +196,7 @@ class EmailTwoFactorProviderTest extends TestCase
         $this->generator
             ->expects($this->once())
             ->method('generateAndSend')
-            ->with($user)
-        ;
+            ->with($user);
 
         $this->assertFalse($this->provider->validateAuthenticationCode($user, self::VALID_AUTH_CODE));
     }
@@ -216,8 +215,7 @@ class EmailTwoFactorProviderTest extends TestCase
 
         $this->generator
             ->expects($this->never())
-            ->method('generateAndSend')
-        ;
+            ->method('generateAndSend');
 
         $this->assertFalse($provider->validateAuthenticationCode($user, self::VALID_AUTH_CODE));
     }

--- a/tests/Security/TwoFactor/Provider/Email/EmailTwoFactorProviderTest.php
+++ b/tests/Security/TwoFactor/Provider/Email/EmailTwoFactorProviderTest.php
@@ -201,7 +201,10 @@ class EmailTwoFactorProviderTest extends TestCase
         $this->assertFalse($this->provider->validateAuthenticationCode($user, self::VALID_AUTH_CODE));
     }
 
-    public function validateAuthenticationCode_withExpiredCode_doesNotRegenerateCode(): void
+    /**
+     * @test
+     */
+    public function validateAuthenticationCode_withValidExpiredCode_doesNotRegenerateCode(): void
     {
         $provider = new EmailTwoFactorProvider($this->generator, $this->formRenderer, false);
 
@@ -218,5 +221,27 @@ class EmailTwoFactorProviderTest extends TestCase
             ->method('generateAndSend');
 
         $this->assertFalse($provider->validateAuthenticationCode($user, self::VALID_AUTH_CODE));
+    }
+
+    /**
+     * @test
+     */
+    public function validateAuthenticationCode_withInvalidExpiredCode_doesNotRegenerateCode(): void
+    {
+        $provider = new EmailTwoFactorProvider($this->generator, $this->formRenderer, false);
+
+        $user = $this->createUser();
+
+        $this->generator
+            ->expects($this->once())
+            ->method('isCodeExpired')
+            ->with($user)
+            ->willReturn(true);
+
+        $this->generator
+            ->expects($this->never())
+            ->method('generateAndSend');
+
+        $this->assertFalse($provider->validateAuthenticationCode($user, self::INVALID_AUTH_CODE));
     }
 }

--- a/tests/Security/TwoFactor/Provider/Email/Generator/CodeGeneratorTest.php
+++ b/tests/Security/TwoFactor/Provider/Email/Generator/CodeGeneratorTest.php
@@ -4,18 +4,22 @@ declare(strict_types=1);
 
 namespace Scheb\TwoFactorBundle\Tests\Security\TwoFactor\Provider\Email\Generator;
 
+use DateTimeImmutable;
 use PHPUnit\Framework\MockObject\MockObject;
 use Scheb\TwoFactorBundle\Mailer\AuthCodeMailerInterface;
 use Scheb\TwoFactorBundle\Model\Email\TwoFactorInterface;
 use Scheb\TwoFactorBundle\Model\PersisterInterface;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\Email\Generator\CodeGenerator;
+use Scheb\TwoFactorBundle\Tests\Security\TwoFactor\Provider\Email\TestableTwoFactorInterface;
 use Scheb\TwoFactorBundle\Tests\TestCase;
+use Symfony\Component\Clock\MockClock;
 
 class CodeGeneratorTest extends TestCase
 {
     private MockObject|PersisterInterface $persister;
     private MockObject|AuthCodeMailerInterface $mailer;
     private TestableCodeGenerator $authCodeManager;
+    private MockClock $clock;
 
     protected function setUp(): void
     {
@@ -23,7 +27,9 @@ class CodeGeneratorTest extends TestCase
 
         $this->mailer = $this->createMock(AuthCodeMailerInterface::class);
 
-        $this->authCodeManager = new TestableCodeGenerator($this->persister, $this->mailer, 5);
+        $this->clock = new MockClock();
+
+        $this->authCodeManager = new TestableCodeGenerator($this->persister, $this->mailer, 5, 'PT5M', $this->clock);
         $this->authCodeManager->testCode = 12345;
     }
 
@@ -86,6 +92,27 @@ class CodeGeneratorTest extends TestCase
     /**
      * @test
      */
+    public function generateAndSend_generateNewCode_persistsCreatedAt(): void
+    {
+        // Mock the user object
+        $user = $this->createMock(TestableTwoFactorInterface::class);
+        $user
+            ->expects($this->once())
+            ->method('setEmailAuthCodeCreatedAt')
+            ->with($this->clock->now());
+
+        // Mock the persister
+        $this->persister
+            ->expects($this->once())
+            ->method('persist')
+            ->with($user);
+
+        $this->authCodeManager->generateAndSend($user);
+    }
+
+    /**
+     * @test
+     */
     public function generateAndSend_generateNewCode_sendMail(): void
     {
         // Stub the user object
@@ -115,5 +142,62 @@ class CodeGeneratorTest extends TestCase
             ->with($user);
 
         $this->authCodeManager->reSend($user);
+    }
+
+    /**
+     * @test
+     */
+    public function isExpired_withoutExpiration_returnsFalse(): void
+    {
+        $user = $this->createMock(TestableTwoFactorInterface::class);
+        $user
+            ->expects($this->never())
+            ->method('getEmailAuthCodeCreatedAt');
+
+        $codeGenerator = new TestableCodeGenerator($this->persister, $this->mailer, 5, null, $this->clock);
+
+        $this->assertFalse($codeGenerator->isCodeExpired($user));
+    }
+
+    /**
+     * @test
+     */
+    public function isExpired_withNotExpiringCode_returnsFalse(): void
+    {
+        $user = $this->createMock(TestableTwoFactorInterface::class);
+        $user
+            ->expects($this->once())
+            ->method('getEmailAuthCodeCreatedAt')
+            ->willReturn(null);
+
+        $this->assertFalse($this->authCodeManager->isCodeExpired($user));
+    }
+
+    /**
+     * @test
+     */
+    public function isExpired_withNotExpiredCode_returnsFalse(): void
+    {
+        $user = $this->createMock(TestableTwoFactorInterface::class);
+        $user
+            ->expects($this->once())
+            ->method('getEmailAuthCodeCreatedAt')
+            ->willReturn($this->clock->now());
+
+        $this->assertFalse($this->authCodeManager->isCodeExpired($user));
+    }
+
+    /**
+     * @test
+     */
+    public function isExpired_withExpiredCode_returnsTrue(): void
+    {
+        $user = $this->createMock(TestableTwoFactorInterface::class);
+        $user
+            ->expects($this->once())
+            ->method('getEmailAuthCodeCreatedAt')
+            ->willReturn(new DateTimeImmutable('-6 minutes'));
+
+        $this->assertTrue($this->authCodeManager->isCodeExpired($user));
     }
 }

--- a/tests/Security/TwoFactor/Provider/Email/Generator/TestableCodeGeneratorInterface.php
+++ b/tests/Security/TwoFactor/Provider/Email/Generator/TestableCodeGeneratorInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scheb\TwoFactorBundle\Tests\Security\TwoFactor\Provider\Email\Generator;
+
+use Scheb\TwoFactorBundle\Model\Email\TwoFactorInterface;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\Email\Generator\CodeGeneratorInterface;
+
+interface TestableCodeGeneratorInterface extends CodeGeneratorInterface
+{
+    public function isCodeExpired(TwoFactorInterface $user): bool;
+}

--- a/tests/Security/TwoFactor/Provider/Email/TestableTwoFactorInterface.php
+++ b/tests/Security/TwoFactor/Provider/Email/TestableTwoFactorInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scheb\TwoFactorBundle\Tests\Security\TwoFactor\Provider\Email;
+
+use DateTimeImmutable;
+use Scheb\TwoFactorBundle\Model\Email\TwoFactorInterface;
+
+/**
+ * Used to mock method annotations.
+ */
+interface TestableTwoFactorInterface extends TwoFactorInterface
+{
+    public function getEmailAuthCodeCreatedAt(): DateTimeImmutable|null;
+
+    public function setEmailAuthCodeCreatedAt(DateTimeImmutable|null $createdAt): void;
+}

--- a/tests/Security/TwoFactor/Provider/Email/UserWithTwoFactorInterface.php
+++ b/tests/Security/TwoFactor/Provider/Email/UserWithTwoFactorInterface.php
@@ -4,12 +4,11 @@ declare(strict_types=1);
 
 namespace Scheb\TwoFactorBundle\Tests\Security\TwoFactor\Provider\Email;
 
-use Scheb\TwoFactorBundle\Model\Email\TwoFactorInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
  * Used to mock combined interfaces.
  */
-interface UserWithTwoFactorInterface extends UserInterface, TwoFactorInterface
+interface UserWithTwoFactorInterface extends UserInterface, TestableTwoFactorInterface
 {
 }


### PR DESCRIPTION
See #191 

First off, thanks for taking the time to review ;)

**Description**

Expiring the email authentication code is generally a good idea and could easily be implemented in a custom provider (which I previously did including rate limiting & re-sending in case the email got lost in transit). But having it provided by the bundle with minimal effort for the maintainer is (imo at least) even better as it provides a little bit of extra security straight out of the box.

I think I figured out a way to contribute the expiration feature without breaking BC. This however uses a trick, which depending on how you feel, is a little bit nasty (but Symfony has used it in the past for BC reasons). Using `@method` declarations at the interface level we can check at runtime if the users has implemented the newly added methods and otherwise, to preserve BC, ignore/disable the expiration feature.

The only "BC break", if you can even call it that, is that when someone upgrades to, lets say 7.2 where this is included, their static analysis will bark at them for not implementing the `@method`s from the `TwoFactorInterface` and, in case they have a custom code generator, the `CodeGeneratorInterface`. This however wont break the code and it will still run without any errors at runtime.

---

This feature is currently disabled by default, but could and imo ***should*** be auto enabled with version 8.0 of the bundle:
```yaml
scheb_two_factor:
    email:
        expires_after: PT15M # default is NULL which disables this feature
```

I also added the `resend_expired` option to automatically invoke `CodeGeneratorInterface::generateAndSend` when the user submitted the TFA form and their code has expired. This is enabled by default but only has an effect when `expires_after` is configured.

---

**Maintenance in the future**

Whenever BC is allowed to be broken again, lets assume 8.0, there are some changes that will have to be made to the code base:

- Add the `@method` annotations to the interface properly
- Remove the `method_exists` checks in `CodeGenerator` and `EmailTwoFactorProvider`
- Change `TestableTwoFactorInterface` and `TestableCodeGeneratorInterface` usages to the *real* interfaces in tests and delete them

What are `TestableTwoFactorInterface` and `TestableCodeGeneratorInterface`?

AFAIK and tried to search the docs for, PHPUnit mocks completely ignore `@method` annotations. That's why I added these helper interfaces in tests that do nothing but extend the *real* interface and add the `@method` methods to the interface properly.
