### PR TITLE
Nested IP whitelist

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -82,9 +82,10 @@ Bundle Configuration
        # Supports IPv4, IPv6 and IP subnet masks.
        ip_whitelist:
            - 127.0.0.1  # One IPv4
-           - 192.168.0.0/16  # IPv4 subnet
+           - 192.168.0.0/16  # One IPv4 subnet
            - 2001:0db8:85a3:0000:0000:8a2e:0370:7334  # One IPv6
-           - 2001:db8:abcd:0012::0/64  # IPv6 subnet
+           - 2001:db8:abcd:0012::0/64  # One IPv6 subnet
+           - !php/const Symfony\Component\HttpFoundation\IpUtils::PRIVATE_SUBNETS # All private IPv4 and IPv6 subnets
 
        # If you want to have your own implementation to retrieve the whitelisted IPs.
        # The configuration option "ip_whitelist" becomes meaningless in that case.

--- a/src/bundle/DependencyInjection/Configuration.php
+++ b/src/bundle/DependencyInjection/Configuration.php
@@ -15,6 +15,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Http\Authenticator\Token\PostAuthenticationToken;
 use function interface_exists;
+use function is_iterable;
 
 /**
  * @final
@@ -225,12 +226,14 @@ class Configuration implements ConfigurationInterface
     }
 
     /**
+     * @param iterable<mixed> $iterableValue
+     *
      * @return iterable<mixed>
      */
-    private static function flatten(array $arrayValue): iterable
+    private static function flatten(iterable $iterableValue): iterable
     {
-        foreach ($arrayValue as $value) {
-            if (is_array($value)) {
+        foreach ($iterableValue as $value) {
+            if (is_iterable($value)) {
                 foreach (self::flatten($value) as $x) {
                     yield $x;
                 }

--- a/src/bundle/DependencyInjection/Configuration.php
+++ b/src/bundle/DependencyInjection/Configuration.php
@@ -42,6 +42,17 @@ class Configuration implements ConfigurationInterface
                     ->prototype('scalar')->end()
                 ->end()
                 ->arrayNode('ip_whitelist')
+                    ->beforeNormalization()
+                        ->ifArray()
+                        ->then(static function (mixed $value): array {
+                            $values = [];
+                            foreach (self::flatten($value) as $v) {
+                                $values[] = $v;
+                            }
+
+                            return $values;
+                        })
+                    ->end()
                     ->defaultValue([])
                     ->prototype('scalar')->end()
                 ->end()
@@ -211,5 +222,23 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
             ->end();
+    }
+
+    /**
+     * @return iterable<mixed>
+     */
+    private static function flatten(array $arrayValue): iterable
+    {
+        foreach ($arrayValue as $value) {
+            if (is_array($value)) {
+                foreach (self::flatten($value) as $x) {
+                    yield $x;
+                }
+
+                continue;
+            }
+
+            yield $value;
+        }
     }
 }

--- a/src/bundle/DependencyInjection/Configuration.php
+++ b/src/bundle/DependencyInjection/Configuration.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Scheb\TwoFactorBundle\DependencyInjection;
 
+use RecursiveArrayIterator;
+use RecursiveIteratorIterator;
 use Scheb\TwoFactorBundle\Model\BackupCodeInterface;
 use Scheb\TwoFactorBundle\Model\Email\TwoFactorInterface as EMailTwoFactorInterface;
 use Scheb\TwoFactorBundle\Model\Google\TwoFactorInterface as GoogleTwoFactorInterface;
@@ -15,7 +17,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Http\Authenticator\Token\PostAuthenticationToken;
 use function interface_exists;
-use function is_iterable;
+use function iterator_to_array;
 
 /**
  * @final
@@ -45,13 +47,8 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('ip_whitelist')
                     ->beforeNormalization()
                         ->ifArray()
-                        ->then(static function (mixed $value): array {
-                            $values = [];
-                            foreach (self::flatten($value) as $v) {
-                                $values[] = $v;
-                            }
-
-                            return $values;
+                        ->then(static function (array $value): array {
+                            return iterator_to_array(new RecursiveIteratorIterator(new RecursiveArrayIterator($value)), false);
                         })
                     ->end()
                     ->defaultValue([])
@@ -223,25 +220,5 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
             ->end();
-    }
-
-    /**
-     * @param iterable<mixed> $iterableValue
-     *
-     * @return iterable<mixed>
-     */
-    private static function flatten(iterable $iterableValue): iterable
-    {
-        foreach ($iterableValue as $value) {
-            if (is_iterable($value)) {
-                foreach (self::flatten($value) as $x) {
-                    yield $x;
-                }
-
-                continue;
-            }
-
-            yield $value;
-        }
     }
 }

--- a/tests/DependencyInjection/SchebTwoFactorExtensionTest.php
+++ b/tests/DependencyInjection/SchebTwoFactorExtensionTest.php
@@ -99,7 +99,7 @@ class SchebTwoFactorExtensionTest extends TestCase
         $this->assertHasParameter('cookie.example.org', 'scheb_two_factor.trusted_device.cookie_domain');
         $this->assertHasParameter('/cookie-path', 'scheb_two_factor.trusted_device.cookie_path');
         $this->assertHasParameter(['Symfony\Component\Security\Core\Authentication\Token\SomeToken'], 'scheb_two_factor.security_tokens');
-        $this->assertHasParameter(['127.0.0.1'], 'scheb_two_factor.ip_whitelist');
+        $this->assertHasParameter(['127.0.0.1', '10.0.0.0/8', '192.168.0.0/16'], 'scheb_two_factor.ip_whitelist');
     }
 
     /**
@@ -647,6 +647,7 @@ security_tokens:
     - Symfony\Component\Security\Core\Authentication\Token\SomeToken
 ip_whitelist:
     - 127.0.0.1
+    - ['10.0.0.0/8', '192.168.0.0/16']
 ip_whitelist_provider: acme_test.ip_whitelist_provider
 two_factor_token_factory: acme_test.two_factor_token_factory
 two_factor_provider_decider: acme_test.two_factor_provider_decider


### PR DESCRIPTION
**Description**

This PR introduces support for array values in the `scheb_two_factor.ip_whitelist` configuration option. This allows the user to specify the new-ish [IpUtils::PRIVATE_SUBNETS](https://github.com/symfony/symfony/blob/7.1/src/Symfony/Component/HttpFoundation/IpUtils.php) constant together with some public IPs.

```yaml
scheb_two_factor:
    # This already worked
    ip_whitelist: !php/const Symfony\Component\HttpFoundation\IpUtils::PRIVATE_SUBNETS
```

Now this works as well:

```yaml
scheb_two_factor:
    ip_whitelist:
        - 9.9.9.9
        - [1.1.1.1, 1.0.0.1] 
        - !php/const Symfony\Component\HttpFoundation\IpUtils::PRIVATE_SUBNETS
