### PR TITLE
Add missing space to external packagist link

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -48,7 +48,7 @@ The bundle supports the following authentication methods out of the box:
 .. note::
 
     There are 3rd-party packages for adding different two-factor authentication methods. Check out the
-    `related packages on Packagist.org<https://packagist.org/packages/scheb/2fa-bundle/dependents>`_.
+    `related packages on Packagist.org <https://packagist.org/packages/scheb/2fa-bundle/dependents>`_.
 
 * `Webauthn via jbtronics/2fa-webauthn <https://github.com/jbtronics/2fa-webauthn>`_
 * `Text (SMS) messages via erkens/2fa-text <https://github.com/erkens/2fa-text>`_

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -45,7 +45,7 @@ Optionally, install any additional packages to extend the bundle's feature accor
 .. note::
 
     There are 3rd-party packages for adding different two-factor authentication methods. Check out the
-    `related packages on Packagist.org<https://packagist.org/packages/scheb/2fa-bundle/dependents>`_.
+    `related packages on Packagist.org <https://packagist.org/packages/scheb/2fa-bundle/dependents>`_.
 
 Step 2: Enable the bundle
 ~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Add required space seperator to external Packagist link.

![Screenshot_20240206_235808](https://github.com/scheb/2fa/assets/48986191/cce25cb5-73f1-435c-87fd-0d1492510c53)
