### PR TITLE
[Doc] Fixed some minor syntax issues

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -48,7 +48,7 @@ The bundle supports the following authentication methods out of the box:
 .. note::
 
     There are 3rd-party packages for adding different two-factor authentication methods. Check out the
-    `related packages on Packagist.org<https://packagist.org/packages/scheb/2fa-bundle/dependents>`_.
+    `related packages on Packagist.org <https://packagist.org/packages/scheb/2fa-bundle/dependents>`__.
 
 * `Webauthn via jbtronics/2fa-webauthn <https://github.com/jbtronics/2fa-webauthn>`_
 * `Text messages via erkens/2fa-text <https://github.com/erkens/2fa-text>`_

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -45,7 +45,7 @@ Optionally, install any additional packages to extend the bundle's feature accor
 .. note::
 
     There are 3rd-party packages for adding different two-factor authentication methods. Check out the
-    `related packages on Packagist.org<https://packagist.org/packages/scheb/2fa-bundle/dependents>`_.
+    `related packages on Packagist.org <https://packagist.org/packages/scheb/2fa-bundle/dependents>`__.
 
 Step 2: Enable the bundle
 ~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This fixes the following errors when building docs:

```
Errors for SchebTwoFactorBundle / 6.x

Found invalid reference "related packages on Packagist.org<https://packagist.org/packages/scheb/2fa-bundle/dependents>" in file "installation"

Found invalid reference "related packages on Packagist.org<https://packagist.org/packages/scheb/2fa-bundle/dependents>" in file "index"
```

In RST, the syntax for links is:

For links that appear more than once in the docs and that define their URL separately:

```rst
`The link text`_

.. _`The link text`: https://example.com
```

For one-time links that define their URL embedded:

```rst
`The link text <https://example.com>`__
```

**CAUTION**: in the second case, the link ends with 2 underscores (`__`) instead of just one as in the first case (`_`)