### PR TITLE
introduce CacheableVoterInterface to reduce amounts of calls

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -11,6 +11,7 @@ $rules = [
     'phpdoc_separation' => ['groups' => [['test', 'dataProvider']]],
     'nullable_type_declaration_for_default_null_value' => true,
     'no_superfluous_phpdoc_tags' => ['remove_inheritdoc' => false],
+    'nullable_type_declaration' => false,
 ];
 
 $finder = PhpCsFixer\Finder::create()

--- a/src/bundle/Security/Authorization/Voter/TwoFactorInProgressVoter.php
+++ b/src/bundle/Security/Authorization/Voter/TwoFactorInProgressVoter.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Scheb\TwoFactorBundle\Security\Authorization\Voter;
 
 use Scheb\TwoFactorBundle\Security\Authentication\Token\TwoFactorTokenInterface;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Core\Authorization\Voter\CacheableVoterInterface;
@@ -47,6 +46,6 @@ class TwoFactorInProgressVoter implements CacheableVoterInterface
 
     public function supportsType(string $subjectType): bool
     {
-        return $subjectType === 'null' || $subjectType === Request::class;
+        return true;
     }
 }

--- a/src/bundle/Security/Authorization/Voter/TwoFactorInProgressVoter.php
+++ b/src/bundle/Security/Authorization/Voter/TwoFactorInProgressVoter.php
@@ -41,7 +41,7 @@ class TwoFactorInProgressVoter implements CacheableVoterInterface
 
     public function supportsAttribute(string $attribute): bool
     {
-        return $attribute === self::IS_AUTHENTICATED_2FA_IN_PROGRESS || $attribute === AuthenticatedVoter::PUBLIC_ACCESS;
+        return self::IS_AUTHENTICATED_2FA_IN_PROGRESS === $attribute || AuthenticatedVoter::PUBLIC_ACCESS === $attribute;
     }
 
     public function supportsType(string $subjectType): bool

--- a/src/bundle/Security/Authorization/Voter/TwoFactorInProgressVoter.php
+++ b/src/bundle/Security/Authorization/Voter/TwoFactorInProgressVoter.php
@@ -7,12 +7,13 @@ namespace Scheb\TwoFactorBundle\Security\Authorization\Voter;
 use Scheb\TwoFactorBundle\Security\Authentication\Token\TwoFactorTokenInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Core\Authorization\Voter\CacheableVoterInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
 /**
  * @final
  */
-class TwoFactorInProgressVoter implements VoterInterface
+class TwoFactorInProgressVoter implements CacheableVoterInterface
 {
     public const IS_AUTHENTICATED_2FA_IN_PROGRESS = 'IS_AUTHENTICATED_2FA_IN_PROGRESS';
 
@@ -36,5 +37,15 @@ class TwoFactorInProgressVoter implements VoterInterface
         }
 
         return VoterInterface::ACCESS_ABSTAIN;
+    }
+
+    public function supportsAttribute(string $attribute): bool
+    {
+        return $attribute === self::IS_AUTHENTICATED_2FA_IN_PROGRESS || $attribute === AuthenticatedVoter::PUBLIC_ACCESS;
+    }
+
+    public function supportsType(string $subjectType): bool
+    {
+        return $subjectType === 'null';
     }
 }

--- a/src/bundle/Security/Authorization/Voter/TwoFactorInProgressVoter.php
+++ b/src/bundle/Security/Authorization/Voter/TwoFactorInProgressVoter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Scheb\TwoFactorBundle\Security\Authorization\Voter;
 
 use Scheb\TwoFactorBundle\Security\Authentication\Token\TwoFactorTokenInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Core\Authorization\Voter\CacheableVoterInterface;
@@ -46,6 +47,6 @@ class TwoFactorInProgressVoter implements CacheableVoterInterface
 
     public function supportsType(string $subjectType): bool
     {
-        return $subjectType === 'null';
+        return $subjectType === 'null' || $subjectType === Request::class;
     }
 }

--- a/tests/Security/Authorization/Voter/TwoFactorInProgressVoterTest.php
+++ b/tests/Security/Authorization/Voter/TwoFactorInProgressVoterTest.php
@@ -10,6 +10,7 @@ use Scheb\TwoFactorBundle\Tests\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
 
 class TwoFactorInProgressVoterTest extends TestCase
 {
@@ -49,6 +50,59 @@ class TwoFactorInProgressVoterTest extends TestCase
         return [
             // Abstain
             [null, VoterInterface::ACCESS_ABSTAIN],
+            ['any', VoterInterface::ACCESS_ABSTAIN],
+            [AuthenticatedVoter::IS_AUTHENTICATED_REMEMBERED, VoterInterface::ACCESS_ABSTAIN],
+            [AuthenticatedVoter::IS_AUTHENTICATED_FULLY, VoterInterface::ACCESS_ABSTAIN],
+
+            // Granted
+            [AuthenticatedVoter::PUBLIC_ACCESS, VoterInterface::ACCESS_GRANTED],
+            [TwoFactorInProgressVoter::IS_AUTHENTICATED_2FA_IN_PROGRESS, VoterInterface::ACCESS_GRANTED],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider provideTypesForSupportCheck
+     */
+    public function supports_type(string $checkType, bool $expectedResult): void
+    {
+        $returnValue = $this->voter->supportsType($checkType);
+        $this->assertEquals($expectedResult, $returnValue);
+    }
+
+    /**
+     * @return array<array<mixed>>
+     */
+    public static function provideTypesForSupportCheck(): array
+    {
+        return [
+            [UserInterface::class, false],
+            ['any', false],
+            ['int', false],
+            ['array', false],
+            ['string', false],
+            ['null', true],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider provideAttributesForSupportCheck
+     */
+    public function supports_attribute(string $attribute, int $expectedResult): void
+    {
+        $returnValue = $this->voter->supportsAttribute($attribute);
+        $this->assertEquals($expectedResult === VoterInterface::ACCESS_GRANTED, $returnValue);
+    }
+
+    /**
+     * Copied from provideAttributeAndExpectedResult() but removed null
+     *
+     * @return array<array<mixed>>
+     */
+    public static function provideAttributesForSupportCheck(): array
+    {
+        return [
             ['any', VoterInterface::ACCESS_ABSTAIN],
             [AuthenticatedVoter::IS_AUTHENTICATED_REMEMBERED, VoterInterface::ACCESS_ABSTAIN],
             [AuthenticatedVoter::IS_AUTHENTICATED_FULLY, VoterInterface::ACCESS_ABSTAIN],

--- a/tests/Security/Authorization/Voter/TwoFactorInProgressVoterTest.php
+++ b/tests/Security/Authorization/Voter/TwoFactorInProgressVoterTest.php
@@ -94,11 +94,11 @@ class TwoFactorInProgressVoterTest extends TestCase
     public function supports_attribute(string $attribute, int $expectedResult): void
     {
         $returnValue = $this->voter->supportsAttribute($attribute);
-        $this->assertEquals($expectedResult === VoterInterface::ACCESS_GRANTED, $returnValue);
+        $this->assertEquals(VoterInterface::ACCESS_GRANTED === $expectedResult, $returnValue);
     }
 
     /**
-     * Copied from provideAttributeAndExpectedResult() but removed null
+     * Copied from provideAttributeAndExpectedResult() but removed null.
      *
      * @return array<array<mixed>>
      */

--- a/tests/Security/Authorization/Voter/TwoFactorInProgressVoterTest.php
+++ b/tests/Security/Authorization/Voter/TwoFactorInProgressVoterTest.php
@@ -77,11 +77,11 @@ class TwoFactorInProgressVoterTest extends TestCase
     public static function provideTypesForSupportCheck(): array
     {
         return [
-            [UserInterface::class, false],
-            ['any', false],
-            ['int', false],
-            ['array', false],
-            ['string', false],
+            [UserInterface::class, true],
+            ['any', true],
+            ['int', true],
+            ['array', true],
+            ['string', true],
             ['null', true],
             [Request::class, true],
         ];

--- a/tests/Security/Authorization/Voter/TwoFactorInProgressVoterTest.php
+++ b/tests/Security/Authorization/Voter/TwoFactorInProgressVoterTest.php
@@ -7,6 +7,7 @@ namespace Scheb\TwoFactorBundle\Tests\Security\Authorization\Voter;
 use Scheb\TwoFactorBundle\Security\Authentication\Token\TwoFactorTokenInterface;
 use Scheb\TwoFactorBundle\Security\Authorization\Voter\TwoFactorInProgressVoter;
 use Scheb\TwoFactorBundle\Tests\TestCase;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
@@ -82,6 +83,7 @@ class TwoFactorInProgressVoterTest extends TestCase
             ['array', false],
             ['string', false],
             ['null', true],
+            [Request::class, true],
         ];
     }
 


### PR DESCRIPTION

Closes #227

**Description**

See #227 as well.

Adds the `Symfony\Component\Security\Core\Authorization\Voter\CacheableVoterInterface` which dramatically reduces the amount of calls to the 2FA specific Voter.