### PR TITLE
fix: make TrustedDeviceTokenStorage conform to ResetInterface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "symfony/http-kernel": "^6.4 || ^7.0",
         "symfony/property-access": "^6.4 || ^7.0",
         "symfony/security-bundle": "^6.4 || ^7.0",
+        "symfony/service-contracts": "^2.5|^3",
         "symfony/twig-bundle": "^6.4 || ^7.0"
     },
     "require-dev": {

--- a/src/bundle/composer.json
+++ b/src/bundle/composer.json
@@ -22,6 +22,7 @@
         "symfony/http-kernel": "^6.4 || ^7.0",
         "symfony/property-access": "^6.4 || ^7.0",
         "symfony/security-bundle": "^6.4 || ^7.0",
+        "symfony/service-contracts": "^2.5|^3",
         "symfony/twig-bundle": "^6.4 || ^7.0"
     },
     "autoload": {

--- a/src/trusted-device/Security/TwoFactor/Trusted/TrustedDeviceTokenStorage.php
+++ b/src/trusted-device/Security/TwoFactor/Trusted/TrustedDeviceTokenStorage.php
@@ -7,6 +7,7 @@ namespace Scheb\TwoFactorBundle\Security\TwoFactor\Trusted;
 use RuntimeException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Contracts\Service\ResetInterface;
 use function array_map;
 use function explode;
 use function implode;
@@ -14,7 +15,7 @@ use function implode;
 /**
  * @final
  */
-class TrustedDeviceTokenStorage
+class TrustedDeviceTokenStorage implements ResetInterface
 {
     private const TOKEN_DELIMITER = ';';
 
@@ -98,6 +99,12 @@ class TrustedDeviceTokenStorage
         }
 
         $this->updateCookie = true;
+    }
+
+    public function reset(): void
+    {
+        $this->updateCookie = false;
+        $this->trustedTokenList = null;
     }
 
     /**

--- a/tests/Security/TwoFactor/Trusted/TrustedDeviceTokenStorageTest.php
+++ b/tests/Security/TwoFactor/Trusted/TrustedDeviceTokenStorageTest.php
@@ -337,4 +337,32 @@ class TrustedDeviceTokenStorageTest extends TestCase
         $returnValue = $this->tokenStorage->getCookieValue();
         $this->assertEquals('validToken', $returnValue);
     }
+
+    /**
+     * @test
+     */
+    public function reset_cookiePreviouslyUpdated_resetUpdatedCookie(): void
+    {
+        $this->tokenStorage->addTrustedToken('username', 'firewallName', 1);
+        $this->assertTrue($this->tokenStorage->hasUpdatedCookie());
+
+        $this->tokenStorage->reset();
+        $this->assertFalse($this->tokenStorage->hasUpdatedCookie());
+    }
+
+    /**
+     * @test
+     */
+    public function reset_cookiePreviouslyUpdated_resetCookieList(): void
+    {
+        $this->stubCookieHasToken('serializedToken');
+        $this->stubDecodeToken(
+            $this->createTokenWithProperties('serializedToken', true, true, false),
+        );
+        $this->assertEquals('serializedToken', $this->tokenStorage->getCookieValue());
+
+        $this->request->cookies->remove('cookieName');
+        $this->tokenStorage->reset();
+        $this->assertEmpty($this->tokenStorage->getCookieValue());
+    }
 }


### PR DESCRIPTION
<!--
👍🎉 First off, thanks for taking the time to contribute! 🎉👍

Here are some tips for you:
 - Please follow the PR contribution guidelines: https://github.com/scheb/2fa/blob/7.x/CONTRIBUTING.md#creating-a-pull-request
 - Don't break backwards compatibility. If you have to, let's discuss! :)
 - Always add/update tests and ensure the build passes
-->

**Description**
<!--
Please provide a clear and concise description of the change.

For bug fixes:
 - What problem does the PR solve?
 - If this fixes an open issue, please link the bug ticket

For new features:
 - What's the motivation for this change? What's the problem you're trying to solve?
 - Why do you think it's a good idea to solve it this way?
-->
In certain scenarios, TrustedDeviceTokenStorage might not be re-instanciated between requests. That's the case when multiple requests are handled by a single worker, like when serving the application with RoadRunner or with FrankenPHP. In that case, the trusted_device cookie leak from a request to another, and break the feature entirely. By implementing ResetInterface, the storage is now properly reseted between requests