### PR TITLE
fix: added missing kernel.reset tag to scheb_two_factor.trusted_token_storage

### DIFF
--- a/src/bundle/Resources/config/trusted_device.php
+++ b/src/bundle/Resources/config/trusted_device.php
@@ -41,6 +41,7 @@ return static function (ContainerConfigurator $container): void {
             ])
 
         ->set('scheb_two_factor.trusted_token_storage', TrustedDeviceTokenStorage::class)
+            ->tag('kernel.reset', ['method' => 'reset'])
             ->lazy(true)
             ->args([
                 service('request_stack'),


### PR DESCRIPTION
<!--
👍🎉 First off, thanks for taking the time to contribute! 🎉👍

Here are some tips for you:
 - Please follow the PR contribution guidelines: https://github.com/scheb/2fa/blob/7.x/CONTRIBUTING.md#creating-a-pull-request
 - Don't break backwards compatibility. If you have to, let's discuss! :)
 - Always add/update tests and ensure the build passes
-->

**Description**
<!--
Please provide a clear and concise description of the change.

For bug fixes:
 - What problem does the PR solve?
 - If this fixes an open issue, please link the bug ticket

For new features:
 - What's the motivation for this change? What's the problem you're trying to solve?
 - Why do you think it's a good idea to solve it this way?
-->
Following #266 ; I feel shameful for not catching that mistake earlier than now…