### PR TITLE
Allow preparation of providers to be optional

### DIFF
--- a/src/bundle/Security/TwoFactor/Provider/TwoFactorProviderInitiator.php
+++ b/src/bundle/Security/TwoFactor/Provider/TwoFactorProviderInitiator.php
@@ -8,6 +8,8 @@ use Scheb\TwoFactorBundle\Security\Authentication\Token\TwoFactorTokenFactoryInt
 use Scheb\TwoFactorBundle\Security\Authentication\Token\TwoFactorTokenInterface;
 use Scheb\TwoFactorBundle\Security\TwoFactor\AuthenticationContextInterface;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\Exception\UnknownTwoFactorProviderException;
+use function array_walk;
+use function count;
 
 /**
  * @final
@@ -21,46 +23,41 @@ class TwoFactorProviderInitiator
     ) {
     }
 
-    /**
-     * @return string[]
-     */
-    private function getActiveTwoFactorProviders(AuthenticationContextInterface $context): array
+    public function beginTwoFactorAuthentication(AuthenticationContextInterface $context): TwoFactorTokenInterface|null
     {
-        $activeTwoFactorProviders = [];
-
         // Iterate over two-factor providers and begin the two-factor authentication process.
+        $activeTwoFactorProviders = $statelessProviders = [];
         foreach ($this->providerRegistry->getAllProviders() as $providerName => $provider) {
             if (!$provider->beginAuthentication($context)) {
                 continue;
             }
 
             $activeTwoFactorProviders[] = $providerName;
-        }
-
-        return $activeTwoFactorProviders;
-    }
-
-    public function beginTwoFactorAuthentication(AuthenticationContextInterface $context): TwoFactorTokenInterface|null
-    {
-        $activeTwoFactorProviders = $this->getActiveTwoFactorProviders($context);
-
-        $authenticatedToken = $context->getToken();
-        if ($activeTwoFactorProviders) {
-            $twoFactorToken = $this->twoFactorTokenFactory->create($authenticatedToken, $context->getFirewallName(), $activeTwoFactorProviders);
-
-            $preferredProvider = $this->twoFactorProviderDecider->getPreferredTwoFactorProvider($activeTwoFactorProviders, $twoFactorToken, $context);
-
-            if (null !== $preferredProvider) {
-                try {
-                    $twoFactorToken->preferTwoFactorProvider($preferredProvider);
-                } catch (UnknownTwoFactorProviderException) {
-                    // Bad user input
-                }
+            if ($provider->needsPreparation()) {
+                continue;
             }
 
-            return $twoFactorToken;
+            $statelessProviders[] = $providerName;
         }
 
-        return null;
+        if (0 === count($activeTwoFactorProviders)) {
+            return null;
+        }
+
+        $twoFactorToken = $this->twoFactorTokenFactory->create($context->getToken(), $context->getFirewallName(), $activeTwoFactorProviders);
+
+        array_walk($statelessProviders, static fn (string $providerName) => $twoFactorToken->setTwoFactorProviderPrepared($providerName));
+
+        $preferredProvider = $this->twoFactorProviderDecider->getPreferredTwoFactorProvider($activeTwoFactorProviders, $twoFactorToken, $context);
+
+        if (null !== $preferredProvider) {
+            try {
+                $twoFactorToken->preferTwoFactorProvider($preferredProvider);
+            } catch (UnknownTwoFactorProviderException) {
+                // Bad user input
+            }
+        }
+
+        return $twoFactorToken;
     }
 }

--- a/src/bundle/Security/TwoFactor/Provider/TwoFactorProviderInterface.php
+++ b/src/bundle/Security/TwoFactor/Provider/TwoFactorProviderInterface.php
@@ -14,7 +14,12 @@ interface TwoFactorProviderInterface
     public function beginAuthentication(AuthenticationContextInterface $context): bool;
 
     /**
-     * Do all steps necessary to prepare authentication, e.g. generate & send a code.
+     * Determine whether this Provider needs to be prepared (if the prepareAuthentication method needs to be called).
+     */
+    public function needsPreparation(): bool;
+
+    /**
+     * Do all steps necessary to prepare authentication, e.g. generate & send a code. Will only be called when needsPreparation() returns true.
      */
     public function prepareAuthentication(object $user): void;
 

--- a/src/email/Security/TwoFactor/Provider/Email/EmailTwoFactorProvider.php
+++ b/src/email/Security/TwoFactor/Provider/Email/EmailTwoFactorProvider.php
@@ -30,6 +30,11 @@ class EmailTwoFactorProvider implements TwoFactorProviderInterface
         return $user instanceof TwoFactorInterface && $user->isEmailAuthEnabled();
     }
 
+    public function needsPreparation(): bool
+    {
+        return true;
+    }
+
     public function prepareAuthentication(object $user): void
     {
         if (!($user instanceof TwoFactorInterface)) {

--- a/src/google-authenticator/Security/TwoFactor/Provider/Google/GoogleAuthenticatorTwoFactorProvider.php
+++ b/src/google-authenticator/Security/TwoFactor/Provider/Google/GoogleAuthenticatorTwoFactorProvider.php
@@ -38,6 +38,11 @@ class GoogleAuthenticatorTwoFactorProvider implements TwoFactorProviderInterface
         return true;
     }
 
+    public function needsPreparation(): bool
+    {
+        return false;
+    }
+
     public function prepareAuthentication(object $user): void
     {
     }

--- a/src/totp/Security/TwoFactor/Provider/Totp/TotpAuthenticatorTwoFactorProvider.php
+++ b/src/totp/Security/TwoFactor/Provider/Totp/TotpAuthenticatorTwoFactorProvider.php
@@ -42,6 +42,11 @@ class TotpAuthenticatorTwoFactorProvider implements TwoFactorProviderInterface
         return true;
     }
 
+    public function needsPreparation(): bool
+    {
+        return false;
+    }
+
     public function prepareAuthentication(object $user): void
     {
     }

--- a/tests/Security/TwoFactor/Provider/TwoFactorProviderInitiatorTest.php
+++ b/tests/Security/TwoFactor/Provider/TwoFactorProviderInitiatorTest.php
@@ -25,7 +25,9 @@ class TwoFactorProviderInitiatorTest extends AbstractAuthenticationContextTestCa
     protected function setUp(): void
     {
         $this->provider1 = $this->createMock(TwoFactorProviderInterface::class);
+        $this->provider1->method('needsPreparation')->willReturn(true);
         $this->provider2 = $this->createMock(TwoFactorProviderInterface::class);
+        $this->provider2->method('needsPreparation')->willReturn(false);
 
         $providerRegistry = $this->createMock(TwoFactorProviderRegistry::class);
         $providerRegistry
@@ -159,6 +161,25 @@ class TwoFactorProviderInitiatorTest extends AbstractAuthenticationContextTestCa
             ->expects($this->once())
             ->method('preferTwoFactorProvider')
             ->with('preferredProvider');
+
+        $this->initiator->beginTwoFactorAuthentication($context);
+    }
+
+    /**
+     * @test
+     */
+    public function beginAuthentication_statelessProviderPrepared_setThatProviderIsPrepared(): void
+    {
+        $originalToken = $this->createToken();
+        $context = $this->createAuthenticationContext(null, $originalToken);
+        $this->stubProvidersReturn(true, true);
+
+        $twoFactorToken = $this->createTwoFactorToken();
+        $twoFactorToken
+            ->expects($this->once())
+            ->method('setTwoFactorProviderPrepared')
+            ->with('test2');
+        $this->stubTwoFactorTokenFactoryReturns($twoFactorToken);
 
         $this->initiator->beginTwoFactorAuthentication($context);
     }


### PR DESCRIPTION
**Description**

To pave the way for stateless 2nd factor authentication the bundle can be made aware of providers that do no need to be prepared.

These providers can be used for stateless auth because there is no need to store the state of the preparation.

This MR skips calling the preparation, storing the state of the preparation and checking this state if the provider does not need to be prepared. It does this by adding a bool method `needsPreparation` to the `ProviderInterface` and checking this method where appropriate.

Unfortunately this is a backwards incompatible change and would require other Provider implementations to add the method.

Also see #265