### PR TITLE
Handle multiple usages of an MFA-code

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -105,6 +105,19 @@ Bundle Configuration
        # Must implement  Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderDeciderInterface
        two_factor_provider_decider: acme.custom_two_factor_provider_decider
 
+       # If you want to disable multiple uses of the same two-factor code (as recommended by
+       # NIST) you can provide a Cache-implementation that will be used to cache the used codes
+       # Must implement Psr\Cache\CacheItemPoolInterface or Symfony\Contracts\Cache\CacheInterface
+       # Remove the key or set the value to an empty string to disable this check
+       code_reuse_cache: acme.custom_code_reuse_cache
+
+       # If you need to handle reused codes differently you can create your own EventListener for the
+       # Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorCodeReusedEvent
+       # The default handler throws a Scheb\TwoFactorBundle\Security\Authentication\Exception\ReusedTwoFactorCodeException
+       # If that is not what you want, you can provide a different default handler here.
+       code_reuse_default_handler: Scheb\TwoFactorBundle\Security\Http\EventListener\ThrowExceptionOnTwoFactorCodeReuseListener
+
+
 Firewall Configuration
 ----------------------
 

--- a/doc/events.rst
+++ b/doc/events.rst
@@ -206,3 +206,23 @@ Constant: ``Scheb\TwoFactorBundle\Security\TwoFactor\Event\TotpCodeEvents::INVAL
 Event class: ``Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorCodeEvent``
 
 Is dispatched when the code was deemed to be a invalid TOTP code.
+
+TOTP Check Events
+-----------------
+
+The following events are dispatched before the TOTP authentication provider is used
+
+``TwoFactorCodeCheckEvent``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Event class: ``\Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorCodeCheckEvent``
+
+Is dispatched before the TOTP authentication provider is used to check the code for plausibility
+
+``TwoFactorCodeReusedEvent``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Event class: ``\Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorCodeReusedEvent``
+
+Is dispatched when the code has been used already within the last 30 seconds.
+This requires a caching backend to be available

--- a/src/bundle/DependencyInjection/SchebTwoFactorExtension.php
+++ b/src/bundle/DependencyInjection/SchebTwoFactorExtension.php
@@ -56,6 +56,7 @@ class SchebTwoFactorExtension extends Extension
         $this->configureIpWhitelistProvider($container, $config);
         $this->configureTokenFactory($container, $config);
         $this->configureProviderDecider($container, $config);
+        $this->configureCodeReuseCache($container, $config);
 
         if (isset($config['trusted_device']['enabled']) && $this->resolveFeatureFlag($container, $config['trusted_device']['enabled'])) {
             $this->configureTrustedDeviceManager($container, $config);
@@ -232,6 +233,24 @@ class SchebTwoFactorExtension extends Extension
         }
 
         $container->setAlias('scheb_two_factor.security.totp.form_renderer', $config['totp']['form_renderer']);
+    }
+
+    /**
+     * @param array<string,mixed> $config
+     */
+    private function configureCodeReuseCache(ContainerBuilder $container, array $config): void
+    {
+        if ($config['code_reuse_cache']??null === null) {
+            $config['code_reuse_cache'] = '';
+        }
+
+        $container->setAlias('scheb_two_factor.code_reuse_cache', $config['code_reuse_cache']);
+
+        if (!($config['code_reuse_default_handler']??null !== null)) {
+            return;
+        }
+
+        $container->setAlias('scheb_two_factor.security.listener.default_code_reuse_listener', $config['code_reuse_default_handler']);
     }
 
     private function resolveFeatureFlag(ContainerBuilder $container, bool|string $value): bool

--- a/src/bundle/Resources/config/security.php
+++ b/src/bundle/Resources/config/security.php
@@ -10,7 +10,9 @@ use Scheb\TwoFactorBundle\Security\Http\Authentication\DefaultAuthenticationRequ
 use Scheb\TwoFactorBundle\Security\Http\Authentication\DefaultAuthenticationSuccessHandler;
 use Scheb\TwoFactorBundle\Security\Http\Authenticator\TwoFactorAuthenticator;
 use Scheb\TwoFactorBundle\Security\Http\EventListener\CheckTwoFactorCodeListener;
+use Scheb\TwoFactorBundle\Security\Http\EventListener\CheckTwoFactorCodeReuseListener;
 use Scheb\TwoFactorBundle\Security\Http\EventListener\SuppressRememberMeListener;
+use Scheb\TwoFactorBundle\Security\Http\EventListener\ThrowExceptionOnTwoFactorCodeReuseListener;
 use Scheb\TwoFactorBundle\Security\Http\Firewall\ExceptionListener;
 use Scheb\TwoFactorBundle\Security\Http\Firewall\TwoFactorAccessListener;
 use Scheb\TwoFactorBundle\Security\Http\Utils\RequestDataReader;
@@ -67,7 +69,19 @@ return static function (ContainerConfigurator $container): void {
             ->args([
                 service('scheb_two_factor.provider_preparation_recorder'),
                 service('scheb_two_factor.provider_registry'),
+                service('event_dispatcher'),
             ])
+        ->set('scheb_two_factor.security.listener.check_two_factor_code_reuse', CheckTwoFactorCodeReuseListener::class)
+            ->tag('kernel.event_subscriber')
+            ->args([
+                service('event_dispatcher'),
+                service('scheb_two_factor.code_reuse_cache'),
+            ])
+
+        ->set('scheb_two_factor.security.listener.throw_exception_on_two_factor_code_reuse', ThrowExceptionOnTwoFactorCodeReuseListener::class)
+            ->tag('kernel.event_subscriber')
+
+        ->alias('scheb_two_factor.security.listener.default_code_reuse_listener', 'scheb_two_factor.security.listener.throw_exception_on_two_factor_code_reuse')
 
         ->set('scheb_two_factor.security.listener.suppress_remember_me', SuppressRememberMeListener::class)
             ->tag('kernel.event_subscriber')

--- a/src/bundle/Security/Authentication/Exception/ReusedTwoFactorCodeException.php
+++ b/src/bundle/Security/Authentication/Exception/ReusedTwoFactorCodeException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scheb\TwoFactorBundle\Security\Authentication\Exception;
+
+use Symfony\Component\Security\Core\Exception\BadCredentialsException;
+
+/**
+ * @final
+ */
+class ReusedTwoFactorCodeException extends BadCredentialsException
+{
+    public const MESSAGE = 'Reused two-factor authentication code.';
+    private const MESSAGE_KEY = 'code_reused';
+
+    public function getMessageKey(): string
+    {
+        return self::MESSAGE_KEY;
+    }
+}

--- a/src/bundle/Security/Http/EventListener/CheckTwoFactorCodeListener.php
+++ b/src/bundle/Security/Http/EventListener/CheckTwoFactorCodeListener.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Scheb\TwoFactorBundle\Security\Http\EventListener;
 
 use InvalidArgumentException;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Scheb\TwoFactorBundle\Security\Authentication\Exception\InvalidTwoFactorCodeException;
 use Scheb\TwoFactorBundle\Security\Authentication\Exception\TwoFactorProviderNotFoundException;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorCodeCheckEvent;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\PreparationRecorderInterface;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderRegistry;
 use Symfony\Component\Security\Http\Event\CheckPassportEvent;
@@ -21,12 +23,15 @@ class CheckTwoFactorCodeListener extends AbstractCheckCodeListener
     public function __construct(
         PreparationRecorderInterface $preparationRecorder,
         private readonly TwoFactorProviderRegistry $providerRegistry,
+        private readonly EventDispatcherInterface $eventDispatcher,
     ) {
         parent::__construct($preparationRecorder);
     }
 
     protected function isValidCode(string $providerName, object $user, string $code): bool
     {
+        $this->eventDispatcher->dispatch(new TwoFactorCodeCheckEvent($user, $code));
+
         try {
             $authenticationProvider = $this->providerRegistry->getProvider($providerName);
         } catch (InvalidArgumentException) {

--- a/src/bundle/Security/Http/EventListener/CheckTwoFactorCodeReuseListener.php
+++ b/src/bundle/Security/Http/EventListener/CheckTwoFactorCodeReuseListener.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scheb\TwoFactorBundle\Security\Http\EventListener;
+
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorCodeCheckEvent;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorCodeReusedEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+use function assert;
+use function sprintf;
+
+/**
+ * @final
+ */
+class CheckTwoFactorCodeReuseListener implements EventSubscriberInterface
+{
+    public const LISTENER_PRIORITY = 0;
+
+    public function __construct(
+        private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly mixed $cache = null,
+    ) {
+    }
+
+    public function checkForCodeReuse(TwoFactorCodeCheckEvent $event): void
+    {
+        if ($this->cache === null) {
+            return;
+        }
+
+        $cacheItem = null;
+        assert($cacheItem instanceof CacheItemInterface || $cacheItem === null);
+        $cacheKey = sprintf(
+            'scheb_two_factor_code_reuse.%1$s.%2$s',
+            $event->getUser()->getUserIdentifier(),
+            $event->getCode(),
+        );
+
+        if ($this->cache instanceof CacheInterface) {
+            $cacheItem = $this->cache->get($cacheKey, static function (ItemInterface $item) {
+                $item->expiresAfter(60);
+                $item->set(true);
+
+                return true;
+            });
+        }
+
+        if ($this->cache instanceof CacheItemPoolInterface) {
+            $cacheItem = $this->cache->getItem($cacheKey);
+            $cacheItem->expiresAfter(60);
+            $cacheItem->set(true);
+            $this->cache->save($cacheItem);
+        }
+
+        if (! $cacheItem instanceof CacheItemInterface) {
+            return;
+        }
+
+        if (!$cacheItem->isHit()) {
+            return;
+        }
+
+        $this->eventDispatcher->dispatch(new TwoFactorCodeReusedEvent($event->getUser(), $event->getCode()));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [TwoFactorCodeCheckEvent::class => ['checkForCodeReuse', self::LISTENER_PRIORITY]];
+    }
+}

--- a/src/bundle/Security/Http/EventListener/ThrowExceptionOnTwoFactorCodeReuseListener.php
+++ b/src/bundle/Security/Http/EventListener/ThrowExceptionOnTwoFactorCodeReuseListener.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scheb\TwoFactorBundle\Security\Http\EventListener;
+
+use Scheb\TwoFactorBundle\Security\Authentication\Exception\ReusedTwoFactorCodeException;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorCodeReusedEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * @final
+ */
+class ThrowExceptionOnTwoFactorCodeReuseListener implements EventSubscriberInterface
+{
+    public const LISTENER_PRIORITY = 256;
+
+    public function handle(TwoFactorCodeReusedEvent $event): void
+    {
+        throw new ReusedTwoFactorCodeException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [TwoFactorCodeReusedEvent::class => ['handle', self::LISTENER_PRIORITY]];
+    }
+}

--- a/src/bundle/Security/TwoFactor/Event/TwoFactorCodeCheckEvent.php
+++ b/src/bundle/Security/TwoFactor/Event/TwoFactorCodeCheckEvent.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scheb\TwoFactorBundle\Security\TwoFactor\Event;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * @final
+ */
+class TwoFactorCodeCheckEvent extends Event
+{
+    /**
+     * @param UserInterface $user
+     */
+    public function __construct(
+        private readonly object $user,
+        private readonly string $code,
+    ) {
+    }
+
+    public function getUser(): object
+    {
+        return $this->user;
+    }
+
+    public function getCode(): string
+    {
+        return $this->code;
+    }
+}

--- a/src/bundle/Security/TwoFactor/Event/TwoFactorCodeReusedEvent.php
+++ b/src/bundle/Security/TwoFactor/Event/TwoFactorCodeReusedEvent.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scheb\TwoFactorBundle\Security\TwoFactor\Event;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * @final
+ */
+class TwoFactorCodeReusedEvent extends Event
+{
+    public function __construct(
+        private readonly object $user,
+        private readonly string $code,
+    ) {
+    }
+
+    public function getUser(): object
+    {
+        return $this->user;
+    }
+
+    public function getCode(): string
+    {
+        return $this->code;
+    }
+}

--- a/tests/Security/Http/EventListener/CheckTwoFactorCodeListenerTest.php
+++ b/tests/Security/Http/EventListener/CheckTwoFactorCodeListenerTest.php
@@ -7,10 +7,12 @@ namespace Scheb\TwoFactorBundle\Tests\Security\Http\EventListener;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Scheb\TwoFactorBundle\Security\Authentication\Exception\InvalidTwoFactorCodeException;
 use Scheb\TwoFactorBundle\Security\Authentication\Exception\TwoFactorProviderNotFoundException;
 use Scheb\TwoFactorBundle\Security\Http\EventListener\CheckTwoFactorCodeListener;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Backup\BackupCodeManagerInterface;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorCodeCheckEvent;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderInterface;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderRegistry;
 
@@ -21,17 +23,27 @@ class CheckTwoFactorCodeListenerTest extends AbstractCheckCodeListenerTestSetup
 {
     private MockObject|BackupCodeManagerInterface $providerRegistry;
 
+    private MockObject|EventDispatcherInterface $eventDispatcher;
+
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->providerRegistry = $this->createMock(TwoFactorProviderRegistry::class);
-        $this->listener = new CheckTwoFactorCodeListener($this->preparationRecorder, $this->providerRegistry);
+        $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $this->listener = new CheckTwoFactorCodeListener(
+            $this->preparationRecorder,
+            $this->providerRegistry,
+            $this->eventDispatcher,
+        );
     }
 
     protected function expectDoNothing(): void
     {
         $this->providerRegistry
+            ->expects($this->never())
+            ->method($this->anything());
+        $this->eventDispatcher
             ->expects($this->never())
             ->method($this->anything());
     }
@@ -52,6 +64,11 @@ class CheckTwoFactorCodeListenerTest extends AbstractCheckCodeListenerTestSetup
     {
         $this->stubAllPreconditionsFulfilled();
 
+        $this->eventDispatcher
+            ->expects($this->once())
+            ->method('dispatch')
+            ->with(new TwoFactorCodeCheckEvent($this->user, self::CODE));
+
         $this->providerRegistry
             ->expects($this->once())
             ->method('getProvider')
@@ -69,6 +86,11 @@ class CheckTwoFactorCodeListenerTest extends AbstractCheckCodeListenerTestSetup
     {
         $this->stubAllPreconditionsFulfilled();
 
+        $this->eventDispatcher
+            ->expects($this->once())
+            ->method('dispatch')
+            ->with(new TwoFactorCodeCheckEvent($this->user, self::CODE));
+
         $authenticationProvider = $this->stubTwoFactorAuthenticationProvider();
         $authenticationProvider
             ->expects($this->once())
@@ -85,6 +107,11 @@ class CheckTwoFactorCodeListenerTest extends AbstractCheckCodeListenerTestSetup
     public function checkPassport_invalidCode_unresolvedCredentials(): void
     {
         $this->stubAllPreconditionsFulfilled();
+
+        $this->eventDispatcher
+            ->expects($this->once())
+            ->method('dispatch')
+            ->with(new TwoFactorCodeCheckEvent($this->user, self::CODE));
 
         $authenticationProvider = $this->stubTwoFactorAuthenticationProvider();
         $authenticationProvider

--- a/tests/Security/Http/EventListener/CheckTwoFactorCodeReuseListenerTest.php
+++ b/tests/Security/Http/EventListener/CheckTwoFactorCodeReuseListenerTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scheb\TwoFactorBundle\Tests\Security\Http\EventListener;
+
+use Closure;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Scheb\TwoFactorBundle\Security\Http\EventListener\CheckTwoFactorCodeListener;
+use Scheb\TwoFactorBundle\Security\Http\EventListener\CheckTwoFactorCodeReuseListener;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorCodeCheckEvent;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorCodeReusedEvent;
+use Scheb\TwoFactorBundle\Tests\TestCase;
+use stdClass;
+use Symfony\Component\Cache\CacheItem;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Contracts\Cache\CacheInterface;
+
+/**
+ * @property CheckTwoFactorCodeListener $listener
+ */
+class CheckTwoFactorCodeReuseListenerTest extends TestCase
+{
+    private MockObject|EventDispatcherInterface $eventDispatcher;
+
+    private MockObject|UserInterface $user;
+
+    private const CODE = '123456';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $this->user = $this->createMock(UserInterface::class);
+        $this->user->method('getUserIdentifier')->willReturn('123');
+    }
+
+    protected function expectDoNothing(): void
+    {
+        $this->eventDispatcher
+            ->expects($this->never())
+            ->method($this->anything());
+    }
+
+    #[Test]
+    public function nothingHappensWithoutCacheProvider(): void
+    {
+        $listener = new CheckTwoFactorCodeReuseListener($this->eventDispatcher, null);
+        $this->expectDoNothing();
+
+        $listener->checkForCodeReuse(new TwoFactorCodeCheckEvent($this->user, self::CODE));
+    }
+
+    #[Test]
+    public function nothingHappensWithNoneCacheObjectAsCacheProvider(): void
+    {
+        $listener = new CheckTwoFactorCodeReuseListener($this->eventDispatcher, new stdClass());
+        $this->expectDoNothing();
+
+        $listener->checkForCodeReuse(new TwoFactorCodeCheckEvent($this->user, self::CODE));
+    }
+
+    #[Test]
+    public function nothingHappensWithSymfonyCacheProvider_noHit(): void
+    {
+        $cacheProvider = $this->createMock(CacheInterface::class);
+        $cacheProvider->expects($this->once())
+            ->method('get')->willReturnCallback(function (string $key, Closure $callback) {
+                $this->assertEquals('scheb_two_factor_code_reuse.123.123456', $key);
+
+                return $callback(new CacheItem());
+            });
+
+        $listener = new CheckTwoFactorCodeReuseListener($this->eventDispatcher, $cacheProvider);
+        $this->expectDoNothing();
+
+        $listener->checkForCodeReuse(new TwoFactorCodeCheckEvent($this->user, self::CODE));
+    }
+
+    #[Test]
+    public function nothingHappensWithPsrCacheProvider_noHit(): void
+    {
+        $cacheProvider = $this->createMock(CacheItemPoolInterface::class);
+        $cacheItem = new CacheItem();
+        $cacheProvider->expects($this->once())
+            ->method('getItem')->willReturnCallback(function (string $key) use ($cacheItem) {
+                $this->assertEquals('scheb_two_factor_code_reuse.123.123456', $key);
+                $cacheItem->set(true);
+                $cacheItem->expiresAfter(60);
+
+                return $cacheItem;
+            });
+
+        $listener = new CheckTwoFactorCodeReuseListener($this->eventDispatcher, $cacheProvider);
+        $this->expectDoNothing();
+
+        $listener->checkForCodeReuse(new TwoFactorCodeCheckEvent($this->user, self::CODE));
+    }
+
+    #[Test]
+    public function codeReusedEventIsDispatchedWithCacheHit(): void
+    {
+        $cacheProvider = $this->createMock(CacheItemPoolInterface::class);
+
+        $cacheItem = $this->createMock(CacheItemInterface::class);
+        $cacheItem->expects($this->once())->method('isHit')->willReturn(true);
+
+        $cacheProvider->expects($this->once())
+            ->method('getItem')
+            ->willReturn($cacheItem);
+
+        $this->eventDispatcher->expects($this->once())
+            ->method('dispatch')
+            ->with(new TwoFactorCodeReusedEvent($this->user, self::CODE));
+
+        $listener = new CheckTwoFactorCodeReuseListener($this->eventDispatcher, $cacheProvider);
+
+        $listener->checkForCodeReuse(new TwoFactorCodeCheckEvent($this->user, self::CODE));
+    }
+}

--- a/tests/Security/Http/EventListener/ThrowExceptionOnTwoFactorReuseListenerTest.php
+++ b/tests/Security/Http/EventListener/ThrowExceptionOnTwoFactorReuseListenerTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scheb\TwoFactorBundle\Tests\Security\Http\EventListener;
+
+use PHPUnit\Framework\Attributes\Test;
+use Scheb\TwoFactorBundle\Security\Authentication\Exception\ReusedTwoFactorCodeException;
+use Scheb\TwoFactorBundle\Security\Http\EventListener\CheckTwoFactorCodeListener;
+use Scheb\TwoFactorBundle\Security\Http\EventListener\ThrowExceptionOnTwoFactorCodeReuseListener;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorCodeReusedEvent;
+use Scheb\TwoFactorBundle\Tests\TestCase;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * @property CheckTwoFactorCodeListener $listener
+ */
+class ThrowExceptionOnTwoFactorReuseListenerTest extends TestCase
+{
+    #[Test]
+    public function throwExceptionWhenUsed(): void
+    {
+        $listener = new ThrowExceptionOnTwoFactorCodeReuseListener();
+
+        $this->expectException(ReusedTwoFactorCodeException::class);
+
+        $listener->handle(new TwoFactorCodeReusedEvent(
+            $this->createMock(UserInterface::class),
+            '123456',
+        ));
+    }
+
+    #[Test]
+    public function EventIsHandledWithCorrectPriority(): void
+    {
+        $this->assertSame([
+            TwoFactorCodeReusedEvent::class => ['handle', 256],
+        ], ThrowExceptionOnTwoFactorCodeReuseListener::getSubscribedEvents());
+    }
+}


### PR DESCRIPTION
This PR introduces the possibility to handle reuse of MFA-codes as discussed in #276 

I also made the default event-handler for the `TwoFactorCodeReusedEvent` configurable to allow easier disabling. 

The tests were passing, PHPCodesniffer was happy as well, the docs are updated and I hope I didn't butcher the config too much.

Any feedback is much appreciated!