### PR TITLE
provide default values for totp configuration

### DIFF
--- a/doc/providers/totp.rst
+++ b/doc/providers/totp.rst
@@ -94,7 +94,9 @@ and the period of the temporary codes.
            public function getTotpAuthenticationConfiguration(): ?TotpConfigurationInterface
            {
                // You could persist the other configuration options in the user entity to make it individual per user.
-               return null !== $this->totpSecret ? new TotpConfiguration($this->totpSecret, TotpConfiguration::ALGORITHM_SHA1, 20, 8) : null;
+               $period = 20;
+               $digits = 6;
+               return null !== $this->totpSecret ? new TotpConfiguration($this->totpSecret, TotpConfiguration::ALGORITHM_SHA1, $period, $digits) : null;
            }
        }
 


### PR DESCRIPTION
<!--
👍🎉 First off, thanks for taking the time to contribute! 🎉👍

Here are some tips for you:
 - Please follow the PR contribution guidelines: https://github.com/scheb/2fa/blob/7.x/CONTRIBUTING.md#creating-a-pull-request
 - Don't break backwards compatibility. If you have to, let's discuss! :)
 - Always add/update tests and ensure the build passes
-->

**Description**
<!--
Please provide a clear and concise description of the change.

For bug fixes:
 - What problem does the PR solve?
 - If this fixes an open issue, please link the bug ticket

For new features:
 - What's the motivation for this change? What's the problem you're trying to solve?
 - Why do you think it's a good idea to solve it this way?
-->

The doc (at doc/providers/totp.rst) says that there are some default value. This commit ensure those are the values actually used if the user does not provide those.
It also update a snippet in that doc to ensure its clear for readers what each value stands for.