### PR TITLE
Add validator for a user's TOTP code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "psr/container": ">=1.1",
         "squizlabs/php_codesniffer": "^4.0",
         "symfony/mailer": "^6.4 || ^7.0",
+        "symfony/validator": "^6.4 || ^7.0",
         "symfony/yaml": "^6.4 || ^7.0",
         "vimeo/psalm": "^6.0"
     },

--- a/src/bundle/Resources/config/two_factor_provider_google.php
+++ b/src/bundle/Resources/config/two_factor_provider_google.php
@@ -7,6 +7,7 @@ use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\Google\GoogleAuthenticator
 use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\Google\GoogleAuthenticatorInterface;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\Google\GoogleAuthenticatorTwoFactorProvider;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\Google\GoogleTotpFactory;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Validator\Constraints\UserGoogleTotpCodeValidator;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ReferenceConfigurator;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
@@ -42,6 +43,12 @@ return static function (ContainerConfigurator $container): void {
             ->args([
                 service('scheb_two_factor.security.google_authenticator'),
                 service('scheb_two_factor.security.google.form_renderer'),
+            ])
+
+        ->set('scheb_two_factor.security.totp.validator.user_google_totp_code', UserGoogleTotpCodeValidator::class)
+            ->args([
+                service('security.token_storage'),
+                service('scheb_two_factor.security.google_authenticator'),
             ])
 
         ->alias('scheb_two_factor.security.google.form_renderer', 'scheb_two_factor.security.google.default_form_renderer')

--- a/src/bundle/Resources/config/two_factor_provider_totp.php
+++ b/src/bundle/Resources/config/two_factor_provider_totp.php
@@ -7,6 +7,7 @@ use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\Totp\TotpAuthenticator;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\Totp\TotpAuthenticatorInterface;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\Totp\TotpAuthenticatorTwoFactorProvider;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\Totp\TotpFactory;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Validator\Constraints\UserTotpCodeValidator;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ReferenceConfigurator;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
@@ -43,6 +44,12 @@ return static function (ContainerConfigurator $container): void {
             ->args([
                 service('scheb_two_factor.security.totp_authenticator'),
                 service('scheb_two_factor.security.totp.form_renderer'),
+            ])
+
+        ->set('scheb_two_factor.security.totp.validator.user_totp_code', UserTotpCodeValidator::class)
+            ->args([
+                service('security.token_storage'),
+                service('scheb_two_factor.security.totp_authenticator'),
             ])
 
         ->alias('scheb_two_factor.security.totp.form_renderer', 'scheb_two_factor.security.totp.default_form_renderer')

--- a/src/google-authenticator/Security/TwoFactor/Validator/Constraints/UserGoogleTotpCode.php
+++ b/src/google-authenticator/Security/TwoFactor/Validator/Constraints/UserGoogleTotpCode.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scheb\TwoFactorBundle\Security\TwoFactor\Validator\Constraints;
+
+use Attribute;
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Validator constraint for the current user's Google Authenticator TOTP code.
+ *
+ * @final
+ */
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+class UserGoogleTotpCode extends Constraint
+{
+    public const INVALID_TOTP_CODE_ERROR = '6de3acd0-12f5-40eb-a776-2525c4566649';
+
+    protected const ERROR_NAMES = [self::INVALID_TOTP_CODE_ERROR => 'INVALID_TOTP_CODE_ERROR'];
+
+    public string $message = 'code_invalid';
+    public string $translationDomain = 'SchebTwoFactorBundle';
+    public string $service = 'scheb_two_factor.security.totp.validator.user_google_totp_code';
+
+    public function __construct(array|null $options = null, string|null $message = null, string|null $translationDomain = null, string|null $service = null, array|null $groups = null, mixed $payload = null)
+    {
+        parent::__construct($options, $groups, $payload);
+
+        $this->message = $message ?? $this->message;
+        $this->translationDomain = $translationDomain ?? $this->translationDomain;
+        $this->service = $service ?? $this->service;
+    }
+
+    public function validatedBy(): string
+    {
+        return $this->service;
+    }
+}

--- a/src/google-authenticator/Security/TwoFactor/Validator/Constraints/UserGoogleTotpCodeValidator.php
+++ b/src/google-authenticator/Security/TwoFactor/Validator/Constraints/UserGoogleTotpCodeValidator.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scheb\TwoFactorBundle\Security\TwoFactor\Validator\Constraints;
+
+use Scheb\TwoFactorBundle\Model\Google\TwoFactorInterface;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\Google\GoogleAuthenticatorInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use function get_debug_type;
+use function is_string;
+use function sprintf;
+
+/**
+ * Validator for the `UserGoogleTotpCode` constraint.
+ *
+ * @final
+ *
+ * @psalm-suppress PropertyNotSetInConstructor
+ */
+class UserGoogleTotpCodeValidator extends ConstraintValidator
+{
+    public function __construct(
+        private readonly TokenStorageInterface $tokenStorage,
+        private readonly GoogleAuthenticatorInterface $googleAuthenticator,
+    ) {
+    }
+
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof UserGoogleTotpCode) {
+            throw new UnexpectedTypeException($constraint, UserGoogleTotpCode::class);
+        }
+
+        if (null === $value || '' === $value) {
+            $this->context->buildViolation($constraint->message)
+                ->setCode(UserGoogleTotpCode::INVALID_TOTP_CODE_ERROR)
+                ->setTranslationDomain($constraint->translationDomain)
+                ->addViolation();
+
+            return;
+        }
+
+        if (!is_string($value)) {
+            throw new UnexpectedTypeException($value, 'string');
+        }
+
+        $token = $this->tokenStorage->getToken();
+
+        if (null === $token) {
+            throw new AuthenticationCredentialsNotFoundException('Could not find Token object for the current user.');
+        }
+
+        $user = $token->getUser();
+
+        if (!$user instanceof TwoFactorInterface) {
+            throw new ConstraintDefinitionException(sprintf('The "%s" class must implement the "%s" interface.', get_debug_type($user), TwoFactorInterface::class));
+        }
+
+        if ($this->googleAuthenticator->checkCode($user, $value)) {
+            return;
+        }
+
+        $this->context->buildViolation($constraint->message)
+            ->setCode(UserGoogleTotpCode::INVALID_TOTP_CODE_ERROR)
+            ->setTranslationDomain($constraint->translationDomain)
+            ->addViolation();
+    }
+}

--- a/src/google-authenticator/composer.json
+++ b/src/google-authenticator/composer.json
@@ -16,6 +16,9 @@
         "scheb/2fa-bundle": "self.version",
         "spomky-labs/otphp": "^11.0"
     },
+    "suggest": {
+        "symfony/validator": "Needed if you want to use the Google Authenticator TOTP validator constraint"
+    },
     "autoload": {
         "psr-4": {
             "Scheb\\TwoFactorBundle\\": ""

--- a/src/totp/Security/TwoFactor/Validator/Constraints/UserTotpCode.php
+++ b/src/totp/Security/TwoFactor/Validator/Constraints/UserTotpCode.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scheb\TwoFactorBundle\Security\TwoFactor\Validator\Constraints;
+
+use Attribute;
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Validator constraint for the current user's TOTP code.
+ *
+ * @final
+ */
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+class UserTotpCode extends Constraint
+{
+    public const INVALID_TOTP_CODE_ERROR = 'f79333fd-6eef-4394-ab6b-54827e2865b6';
+
+    protected const ERROR_NAMES = [self::INVALID_TOTP_CODE_ERROR => 'INVALID_TOTP_CODE_ERROR'];
+
+    public string $message = 'code_invalid';
+    public string $translationDomain = 'SchebTwoFactorBundle';
+    public string $service = 'scheb_two_factor.security.totp.validator.user_totp_code';
+
+    public function __construct(array|null $options = null, string|null $message = null, string|null $translationDomain = null, string|null $service = null, array|null $groups = null, mixed $payload = null)
+    {
+        parent::__construct($options, $groups, $payload);
+
+        $this->message = $message ?? $this->message;
+        $this->translationDomain = $translationDomain ?? $this->translationDomain;
+        $this->service = $service ?? $this->service;
+    }
+
+    public function validatedBy(): string
+    {
+        return $this->service;
+    }
+}

--- a/src/totp/Security/TwoFactor/Validator/Constraints/UserTotpCodeValidator.php
+++ b/src/totp/Security/TwoFactor/Validator/Constraints/UserTotpCodeValidator.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scheb\TwoFactorBundle\Security\TwoFactor\Validator\Constraints;
+
+use Scheb\TwoFactorBundle\Model\Totp\TwoFactorInterface;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\Totp\TotpAuthenticatorInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use function get_debug_type;
+use function is_string;
+use function sprintf;
+
+/**
+ * Validator for the `UserTotpCode` constraint.
+ *
+ * @final
+ *
+ * @psalm-suppress PropertyNotSetInConstructor
+ */
+class UserTotpCodeValidator extends ConstraintValidator
+{
+    public function __construct(
+        private readonly TokenStorageInterface $tokenStorage,
+        private readonly TotpAuthenticatorInterface $totpAuthenticator,
+    ) {
+    }
+
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof UserTotpCode) {
+            throw new UnexpectedTypeException($constraint, UserTotpCode::class);
+        }
+
+        if (null === $value || '' === $value) {
+            $this->context->buildViolation($constraint->message)
+                ->setCode(UserTotpCode::INVALID_TOTP_CODE_ERROR)
+                ->setTranslationDomain($constraint->translationDomain)
+                ->addViolation();
+
+            return;
+        }
+
+        if (!is_string($value)) {
+            throw new UnexpectedTypeException($value, 'string');
+        }
+
+        $token = $this->tokenStorage->getToken();
+
+        if (null === $token) {
+            throw new AuthenticationCredentialsNotFoundException('Could not find Token object for the current user.');
+        }
+
+        $user = $token->getUser();
+
+        if (!$user instanceof TwoFactorInterface) {
+            throw new ConstraintDefinitionException(sprintf('The "%s" class must implement the "%s" interface.', get_debug_type($user), TwoFactorInterface::class));
+        }
+
+        if ($this->totpAuthenticator->checkCode($user, $value)) {
+            return;
+        }
+
+        $this->context->buildViolation($constraint->message)
+            ->setCode(UserTotpCode::INVALID_TOTP_CODE_ERROR)
+            ->setTranslationDomain($constraint->translationDomain)
+            ->addViolation();
+    }
+}

--- a/src/totp/composer.json
+++ b/src/totp/composer.json
@@ -16,6 +16,9 @@
         "scheb/2fa-bundle": "self.version",
         "spomky-labs/otphp": "^11.0"
     },
+    "suggest": {
+        "symfony/validator": "Needed if you want to use the TOTP validator constraint"
+    },
     "autoload": {
         "psr-4": {
             "Scheb\\TwoFactorBundle\\": ""

--- a/tests/Security/TwoFactor/Validator/Constraints/UserGoogleTotpCodeDummy.php
+++ b/tests/Security/TwoFactor/Validator/Constraints/UserGoogleTotpCodeDummy.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scheb\TwoFactorBundle\Tests\Security\TwoFactor\Validator\Constraints;
+
+use Scheb\TwoFactorBundle\Security\TwoFactor\Validator\Constraints\UserGoogleTotpCode;
+
+class UserGoogleTotpCodeDummy
+{
+    #[UserGoogleTotpCode]
+    public string $a;
+
+    #[UserGoogleTotpCode(message: 'myMessage', translationDomain: 'myDomain', service: 'my_service')]
+    public string $b;
+
+    #[UserGoogleTotpCode(groups: ['my_group'], payload: 'some attached data')]
+    public string $c;
+}

--- a/tests/Security/TwoFactor/Validator/Constraints/UserGoogleTotpCodeDummy.php
+++ b/tests/Security/TwoFactor/Validator/Constraints/UserGoogleTotpCodeDummy.php
@@ -14,6 +14,6 @@ class UserGoogleTotpCodeDummy
     #[UserGoogleTotpCode(message: 'myMessage', translationDomain: 'myDomain', service: 'my_service')]
     public string $b;
 
-    #[UserGoogleTotpCode(groups: ['my_group'], payload: 'some attached data')]
+    #[UserGoogleTotpCode(['groups' => ['my_group'], 'payload' => 'some attached data'])]
     public string $c;
 }

--- a/tests/Security/TwoFactor/Validator/Constraints/UserGoogleTotpCodeTest.php
+++ b/tests/Security/TwoFactor/Validator/Constraints/UserGoogleTotpCodeTest.php
@@ -4,10 +4,7 @@ declare(strict_types=1);
 
 namespace Scheb\TwoFactorBundle\Tests\Security\TwoFactor\Validator\Constraints;
 
-use Generator;
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
-use Scheb\TwoFactorBundle\Security\TwoFactor\Validator\Constraints\UserGoogleTotpCode;
 use Scheb\TwoFactorBundle\Tests\TestCase;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
@@ -15,44 +12,20 @@ use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 class UserGoogleTotpCodeTest extends TestCase
 {
     #[Test]
-    public function validatedBy_objectInitialized_returnDefault(): void
-    {
-        $constraint = new UserGoogleTotpCode();
-
-        $this->assertSame('scheb_two_factor.security.totp.validator.user_google_totp_code', $constraint->validatedBy());
-    }
-
-    #[Test]
-    #[DataProvider('provideServiceValidatedConstraints')]
-    public function validatedBy_customValue_returnValid(UserGoogleTotpCode $constraint): void
-    {
-        $this->assertSame('my_service', $constraint->validatedBy());
-    }
-
-    /**
-     * @return Generator<string, list{UserGoogleTotpCode}>
-     */
-    public static function provideServiceValidatedConstraints(): iterable
-    {
-        yield 'Doctrine style' => [new UserGoogleTotpCode(['service' => 'my_service'])];
-
-        yield 'named arguments' => [new UserGoogleTotpCode(service: 'my_service')];
-
-        $metadata = new ClassMetadata(UserGoogleTotpCodeDummy::class);
-        self::assertTrue((new AttributeLoader())->loadClassMetadata($metadata));
-
-        yield 'attribute' => [$metadata->getPropertyMetadata('b')[0]->getConstraints()[0]];
-    }
-
-    #[Test]
     public function configureConstraintFromAttribute_configurationIsCorrect(): void
     {
         $metadata = new ClassMetadata(UserGoogleTotpCodeDummy::class);
         $this->assertTrue((new AttributeLoader())->loadClassMetadata($metadata));
 
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
+        $this->assertSame('code_invalid', $aConstraint->message);
+        $this->assertSame('SchebTwoFactorBundle', $aConstraint->translationDomain);
+        $this->assertSame('scheb_two_factor.security.totp.validator.user_google_totp_code', $aConstraint->validatedBy());
+
         [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         $this->assertSame('myMessage', $bConstraint->message);
         $this->assertSame('myDomain', $bConstraint->translationDomain);
+        $this->assertSame('my_service', $bConstraint->validatedBy());
         $this->assertSame(['Default', 'UserGoogleTotpCodeDummy'], $bConstraint->groups);
         $this->assertNull($bConstraint->payload);
 

--- a/tests/Security/TwoFactor/Validator/Constraints/UserGoogleTotpCodeTest.php
+++ b/tests/Security/TwoFactor/Validator/Constraints/UserGoogleTotpCodeTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scheb\TwoFactorBundle\Tests\Security\TwoFactor\Validator\Constraints;
+
+use Generator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Validator\Constraints\UserGoogleTotpCode;
+use Scheb\TwoFactorBundle\Tests\TestCase;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
+
+class UserGoogleTotpCodeTest extends TestCase
+{
+    #[Test]
+    public function validatedBy_objectInitialized_returnDefault(): void
+    {
+        $constraint = new UserGoogleTotpCode();
+
+        $this->assertSame('scheb_two_factor.security.totp.validator.user_google_totp_code', $constraint->validatedBy());
+    }
+
+    #[Test]
+    #[DataProvider('provideServiceValidatedConstraints')]
+    public function validatedBy_customValue_returnValid(UserGoogleTotpCode $constraint): void
+    {
+        $this->assertSame('my_service', $constraint->validatedBy());
+    }
+
+    /**
+     * @return Generator<string, list{UserGoogleTotpCode}>
+     */
+    public static function provideServiceValidatedConstraints(): iterable
+    {
+        yield 'Doctrine style' => [new UserGoogleTotpCode(['service' => 'my_service'])];
+
+        yield 'named arguments' => [new UserGoogleTotpCode(service: 'my_service')];
+
+        $metadata = new ClassMetadata(UserGoogleTotpCodeDummy::class);
+        self::assertTrue((new AttributeLoader())->loadClassMetadata($metadata));
+
+        yield 'attribute' => [$metadata->getPropertyMetadata('b')[0]->getConstraints()[0]];
+    }
+
+    #[Test]
+    public function configureConstraintFromAttribute_configurationIsCorrect(): void
+    {
+        $metadata = new ClassMetadata(UserGoogleTotpCodeDummy::class);
+        $this->assertTrue((new AttributeLoader())->loadClassMetadata($metadata));
+
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
+        $this->assertSame('myMessage', $bConstraint->message);
+        $this->assertSame('myDomain', $bConstraint->translationDomain);
+        $this->assertSame(['Default', 'UserGoogleTotpCodeDummy'], $bConstraint->groups);
+        $this->assertNull($bConstraint->payload);
+
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
+        $this->assertSame(['my_group'], $cConstraint->groups);
+        $this->assertSame('some attached data', $cConstraint->payload);
+    }
+}

--- a/tests/Security/TwoFactor/Validator/Constraints/UserGoogleTotpCodeValidatorTest.php
+++ b/tests/Security/TwoFactor/Validator/Constraints/UserGoogleTotpCodeValidatorTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scheb\TwoFactorBundle\Tests\Security\TwoFactor\Validator\Constraints;
+
+use Generator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\Google\GoogleAuthenticatorInterface;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Validator\Constraints\UserGoogleTotpCode;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Validator\Constraints\UserGoogleTotpCodeValidator;
+use Scheb\TwoFactorBundle\Tests\Security\TwoFactor\Provider\Google\UserWithTwoFactorInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+/**
+ * @implements ConstraintValidatorTestCase<UserGoogleTotpCodeValidator>
+ */
+class UserGoogleTotpCodeValidatorTest extends ConstraintValidatorTestCase
+{
+    protected TokenStorageInterface $tokenStorage;
+    protected GoogleAuthenticatorInterface&MockObject $googleAuthenticator;
+
+    protected function createValidator(): UserGoogleTotpCodeValidator
+    {
+        return new UserGoogleTotpCodeValidator($this->tokenStorage, $this->googleAuthenticator);
+    }
+
+    protected function setUp(): void
+    {
+        $user = $this->createUser();
+        $this->tokenStorage = $this->createTokenStorage($user);
+        $this->googleAuthenticator = $this->createGoogleAuthenticator();
+
+        parent::setUp();
+    }
+
+    #[Test]
+    #[DataProvider('provideConstraints')]
+    public function validate_validCode_noViolation(UserGoogleTotpCode $constraint): void
+    {
+        $this->googleAuthenticator
+            ->expects($this->any())
+            ->method('checkCode')
+            ->willReturn(true);
+
+        $this->validator->validate('secret', $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    #[Test]
+    #[DataProvider('provideConstraints')]
+    public function validate_invalidCode_raisedViolation(UserGoogleTotpCode $constraint): void
+    {
+        $this->googleAuthenticator
+            ->expects($this->any())
+            ->method('checkCode')
+            ->willReturn(false);
+
+        $this->validator->validate('secret', $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setCode(UserGoogleTotpCode::INVALID_TOTP_CODE_ERROR)
+            ->setTranslationDomain('myDomain')
+            ->assertRaised();
+    }
+
+    /**
+     * @return Generator<string, list{UserGoogleTotpCode}>
+     */
+    public static function provideConstraints(): iterable
+    {
+        yield 'Doctrine style' => [new UserGoogleTotpCode(['message' => 'myMessage', 'translationDomain' => 'myDomain'])];
+
+        yield 'named arguments' => [new UserGoogleTotpCode(message: 'myMessage', translationDomain: 'myDomain')];
+    }
+
+    #[Test]
+    #[DataProvider('emptyTotpCodeData')]
+    public function validate_emptyCode_raisedViolation(string|null $code): void
+    {
+        $constraint = new UserGoogleTotpCode(['message' => 'myMessage']);
+
+        $this->validator->validate($code, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setCode(UserGoogleTotpCode::INVALID_TOTP_CODE_ERROR)
+            ->setTranslationDomain('myDomain')
+            ->assertRaised();
+    }
+
+    /**
+     * @return list<array{string|null}>
+     */
+    public static function emptyTotpCodeData(): array
+    {
+        return [
+            [null],
+            [''],
+        ];
+    }
+
+    #[Test]
+    public function validate_invalidUser_throwsException(): void
+    {
+        // Create a user that doesn't implement TwoFactorInterface
+        $user = $this->createMock(UserInterface::class);
+
+        $this->tokenStorage = $this->createTokenStorage($user);
+        $this->validator = $this->createValidator();
+        $this->validator->initialize($this->context);
+
+        $this->expectException(ConstraintDefinitionException::class);
+
+        $this->validator->validate('secret', new UserGoogleTotpCode());
+    }
+
+    protected function createUser(): UserWithTwoFactorInterface
+    {
+        return $this->createMock(UserWithTwoFactorInterface::class);
+    }
+
+    protected function createGoogleAuthenticator(): GoogleAuthenticatorInterface&MockObject
+    {
+        return $this->createMock(GoogleAuthenticatorInterface::class);
+    }
+
+    protected function createTokenStorage(UserInterface|null $user = null): TokenStorageInterface
+    {
+        $token = $this->createAuthenticationToken($user);
+
+        $mock = $this->createMock(TokenStorageInterface::class);
+        $mock
+            ->expects($this->any())
+            ->method('getToken')
+            ->willReturn($token);
+
+        return $mock;
+    }
+
+    protected function createAuthenticationToken(UserInterface|null $user = null): TokenInterface
+    {
+        $mock = $this->createMock(TokenInterface::class);
+        $mock
+            ->expects($this->any())
+            ->method('getUser')
+            ->willReturn($user);
+
+        return $mock;
+    }
+}

--- a/tests/Security/TwoFactor/Validator/Constraints/UserGoogleTotpCodeValidatorTest.php
+++ b/tests/Security/TwoFactor/Validator/Constraints/UserGoogleTotpCodeValidatorTest.php
@@ -23,8 +23,8 @@ use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
  */
 class UserGoogleTotpCodeValidatorTest extends ConstraintValidatorTestCase
 {
-    protected TokenStorageInterface $tokenStorage;
-    protected GoogleAuthenticatorInterface&MockObject $googleAuthenticator;
+    private TokenStorageInterface $tokenStorage;
+    private GoogleAuthenticatorInterface&MockObject $googleAuthenticator;
 
     protected function createValidator(): UserGoogleTotpCodeValidator
     {
@@ -121,17 +121,17 @@ class UserGoogleTotpCodeValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate('secret', new UserGoogleTotpCode());
     }
 
-    protected function createUser(): UserWithTwoFactorInterface
+    private function createUser(): UserWithTwoFactorInterface
     {
         return $this->createMock(UserWithTwoFactorInterface::class);
     }
 
-    protected function createGoogleAuthenticator(): GoogleAuthenticatorInterface&MockObject
+    private function createGoogleAuthenticator(): GoogleAuthenticatorInterface&MockObject
     {
         return $this->createMock(GoogleAuthenticatorInterface::class);
     }
 
-    protected function createTokenStorage(UserInterface|null $user = null): TokenStorageInterface
+    private function createTokenStorage(UserInterface|null $user = null): TokenStorageInterface
     {
         $token = $this->createAuthenticationToken($user);
 
@@ -144,7 +144,7 @@ class UserGoogleTotpCodeValidatorTest extends ConstraintValidatorTestCase
         return $mock;
     }
 
-    protected function createAuthenticationToken(UserInterface|null $user = null): TokenInterface
+    private function createAuthenticationToken(UserInterface|null $user = null): TokenInterface
     {
         $mock = $this->createMock(TokenInterface::class);
         $mock

--- a/tests/Security/TwoFactor/Validator/Constraints/UserTotpCodeDummy.php
+++ b/tests/Security/TwoFactor/Validator/Constraints/UserTotpCodeDummy.php
@@ -14,6 +14,6 @@ class UserTotpCodeDummy
     #[UserTotpCode(message: 'myMessage', translationDomain: 'myDomain', service: 'my_service')]
     public string $b;
 
-    #[UserTotpCode(groups: ['my_group'], payload: 'some attached data')]
+    #[UserTotpCode(['groups' => ['my_group'], 'payload' => 'some attached data'])]
     public string $c;
 }

--- a/tests/Security/TwoFactor/Validator/Constraints/UserTotpCodeDummy.php
+++ b/tests/Security/TwoFactor/Validator/Constraints/UserTotpCodeDummy.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scheb\TwoFactorBundle\Tests\Security\TwoFactor\Validator\Constraints;
+
+use Scheb\TwoFactorBundle\Security\TwoFactor\Validator\Constraints\UserTotpCode;
+
+class UserTotpCodeDummy
+{
+    #[UserTotpCode]
+    public string $a;
+
+    #[UserTotpCode(message: 'myMessage', translationDomain: 'myDomain', service: 'my_service')]
+    public string $b;
+
+    #[UserTotpCode(groups: ['my_group'], payload: 'some attached data')]
+    public string $c;
+}

--- a/tests/Security/TwoFactor/Validator/Constraints/UserTotpCodeTest.php
+++ b/tests/Security/TwoFactor/Validator/Constraints/UserTotpCodeTest.php
@@ -6,6 +6,7 @@ namespace Scheb\TwoFactorBundle\Tests\Security\TwoFactor\Validator\Constraints;
 
 use Generator;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Validator\Constraints\UserTotpCode;
 use Scheb\TwoFactorBundle\Tests\TestCase;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
@@ -13,17 +14,19 @@ use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 
 class UserTotpCodeTest extends TestCase
 {
-    public function testValidatedByStandardValidator(): void
+    #[Test]
+    public function validatedBy_objectInitialized_returnDefault(): void
     {
         $constraint = new UserTotpCode();
 
-        self::assertSame('scheb_two_factor.security.totp.validator.user_totp_code', $constraint->validatedBy());
+        $this->assertSame('scheb_two_factor.security.totp.validator.user_totp_code', $constraint->validatedBy());
     }
 
+    #[Test]
     #[DataProvider('provideServiceValidatedConstraints')]
-    public function testValidatedByService(UserTotpCode $constraint): void
+    public function validatedBy_customValue_returnValid(UserTotpCode $constraint): void
     {
-        self::assertSame('my_service', $constraint->validatedBy());
+        $this->assertSame('my_service', $constraint->validatedBy());
     }
 
     /**
@@ -41,19 +44,20 @@ class UserTotpCodeTest extends TestCase
         yield 'attribute' => [$metadata->getPropertyMetadata('b')[0]->getConstraints()[0]];
     }
 
-    public function testAttributes(): void
+    #[Test]
+    public function configureConstraintFromAttribute_configurationIsCorrect(): void
     {
         $metadata = new ClassMetadata(UserTotpCodeDummy::class);
-        self::assertTrue((new AttributeLoader())->loadClassMetadata($metadata));
+        $this->assertTrue((new AttributeLoader())->loadClassMetadata($metadata));
 
         [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
-        self::assertSame('myMessage', $bConstraint->message);
-        self::assertSame('myDomain', $bConstraint->translationDomain);
-        self::assertSame(['Default', 'UserTotpCodeDummy'], $bConstraint->groups);
-        self::assertNull($bConstraint->payload);
+        $this->assertSame('myMessage', $bConstraint->message);
+        $this->assertSame('myDomain', $bConstraint->translationDomain);
+        $this->assertSame(['Default', 'UserTotpCodeDummy'], $bConstraint->groups);
+        $this->assertNull($bConstraint->payload);
 
         [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
-        self::assertSame(['my_group'], $cConstraint->groups);
-        self::assertSame('some attached data', $cConstraint->payload);
+        $this->assertSame(['my_group'], $cConstraint->groups);
+        $this->assertSame('some attached data', $cConstraint->payload);
     }
 }

--- a/tests/Security/TwoFactor/Validator/Constraints/UserTotpCodeTest.php
+++ b/tests/Security/TwoFactor/Validator/Constraints/UserTotpCodeTest.php
@@ -4,10 +4,7 @@ declare(strict_types=1);
 
 namespace Scheb\TwoFactorBundle\Tests\Security\TwoFactor\Validator\Constraints;
 
-use Generator;
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
-use Scheb\TwoFactorBundle\Security\TwoFactor\Validator\Constraints\UserTotpCode;
 use Scheb\TwoFactorBundle\Tests\TestCase;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
@@ -15,44 +12,20 @@ use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 class UserTotpCodeTest extends TestCase
 {
     #[Test]
-    public function validatedBy_objectInitialized_returnDefault(): void
-    {
-        $constraint = new UserTotpCode();
-
-        $this->assertSame('scheb_two_factor.security.totp.validator.user_totp_code', $constraint->validatedBy());
-    }
-
-    #[Test]
-    #[DataProvider('provideServiceValidatedConstraints')]
-    public function validatedBy_customValue_returnValid(UserTotpCode $constraint): void
-    {
-        $this->assertSame('my_service', $constraint->validatedBy());
-    }
-
-    /**
-     * @return Generator<string, list{UserTotpCode}>
-     */
-    public static function provideServiceValidatedConstraints(): iterable
-    {
-        yield 'Doctrine style' => [new UserTotpCode(['service' => 'my_service'])];
-
-        yield 'named arguments' => [new UserTotpCode(service: 'my_service')];
-
-        $metadata = new ClassMetadata(UserTotpCodeDummy::class);
-        self::assertTrue((new AttributeLoader())->loadClassMetadata($metadata));
-
-        yield 'attribute' => [$metadata->getPropertyMetadata('b')[0]->getConstraints()[0]];
-    }
-
-    #[Test]
     public function configureConstraintFromAttribute_configurationIsCorrect(): void
     {
         $metadata = new ClassMetadata(UserTotpCodeDummy::class);
         $this->assertTrue((new AttributeLoader())->loadClassMetadata($metadata));
 
+        [$aConstraint] = $metadata->getPropertyMetadata('a')[0]->getConstraints();
+        $this->assertSame('code_invalid', $aConstraint->message);
+        $this->assertSame('SchebTwoFactorBundle', $aConstraint->translationDomain);
+        $this->assertSame('scheb_two_factor.security.totp.validator.user_totp_code', $aConstraint->validatedBy());
+
         [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
         $this->assertSame('myMessage', $bConstraint->message);
         $this->assertSame('myDomain', $bConstraint->translationDomain);
+        $this->assertSame('my_service', $bConstraint->validatedBy());
         $this->assertSame(['Default', 'UserTotpCodeDummy'], $bConstraint->groups);
         $this->assertNull($bConstraint->payload);
 

--- a/tests/Security/TwoFactor/Validator/Constraints/UserTotpCodeTest.php
+++ b/tests/Security/TwoFactor/Validator/Constraints/UserTotpCodeTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scheb\TwoFactorBundle\Tests\Security\TwoFactor\Validator\Constraints;
+
+use Generator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Validator\Constraints\UserTotpCode;
+use Scheb\TwoFactorBundle\Tests\TestCase;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
+
+class UserTotpCodeTest extends TestCase
+{
+    public function testValidatedByStandardValidator(): void
+    {
+        $constraint = new UserTotpCode();
+
+        self::assertSame('scheb_two_factor.security.totp.validator.user_totp_code', $constraint->validatedBy());
+    }
+
+    #[DataProvider('provideServiceValidatedConstraints')]
+    public function testValidatedByService(UserTotpCode $constraint): void
+    {
+        self::assertSame('my_service', $constraint->validatedBy());
+    }
+
+    /**
+     * @return Generator<string, list{UserTotpCode}>
+     */
+    public static function provideServiceValidatedConstraints(): iterable
+    {
+        yield 'Doctrine style' => [new UserTotpCode(['service' => 'my_service'])];
+
+        yield 'named arguments' => [new UserTotpCode(service: 'my_service')];
+
+        $metadata = new ClassMetadata(UserTotpCodeDummy::class);
+        self::assertTrue((new AttributeLoader())->loadClassMetadata($metadata));
+
+        yield 'attribute' => [$metadata->getPropertyMetadata('b')[0]->getConstraints()[0]];
+    }
+
+    public function testAttributes(): void
+    {
+        $metadata = new ClassMetadata(UserTotpCodeDummy::class);
+        self::assertTrue((new AttributeLoader())->loadClassMetadata($metadata));
+
+        [$bConstraint] = $metadata->getPropertyMetadata('b')[0]->getConstraints();
+        self::assertSame('myMessage', $bConstraint->message);
+        self::assertSame('myDomain', $bConstraint->translationDomain);
+        self::assertSame(['Default', 'UserTotpCodeDummy'], $bConstraint->groups);
+        self::assertNull($bConstraint->payload);
+
+        [$cConstraint] = $metadata->getPropertyMetadata('c')[0]->getConstraints();
+        self::assertSame(['my_group'], $cConstraint->groups);
+        self::assertSame('some attached data', $cConstraint->payload);
+    }
+}

--- a/tests/Security/TwoFactor/Validator/Constraints/UserTotpCodeValidatorTest.php
+++ b/tests/Security/TwoFactor/Validator/Constraints/UserTotpCodeValidatorTest.php
@@ -6,6 +6,7 @@ namespace Scheb\TwoFactorBundle\Tests\Security\TwoFactor\Validator\Constraints;
 
 use Generator;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use Scheb\TwoFactorBundle\Model\Totp\TotpConfigurationInterface;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\Totp\TotpAuthenticatorInterface;
@@ -40,11 +41,12 @@ class UserTotpCodeValidatorTest extends ConstraintValidatorTestCase
         parent::setUp();
     }
 
+    #[Test]
     #[DataProvider('provideConstraints')]
-    public function testTotpCodeIsValid(UserTotpCode $constraint): void
+    public function validate_validCode_noViolation(UserTotpCode $constraint): void
     {
         $this->totpAuthenticator
-            ->expects(self::any())
+            ->expects($this->any())
             ->method('checkCode')
             ->willReturn(true);
 
@@ -53,11 +55,12 @@ class UserTotpCodeValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
+    #[Test]
     #[DataProvider('provideConstraints')]
-    public function testTotpCodeIsNotValid(UserTotpCode $constraint): void
+    public function validate_invalidCode_raisedViolation(UserTotpCode $constraint): void
     {
         $this->totpAuthenticator
-            ->expects(self::any())
+            ->expects($this->any())
             ->method('checkCode')
             ->willReturn(false);
 
@@ -79,8 +82,9 @@ class UserTotpCodeValidatorTest extends ConstraintValidatorTestCase
         yield 'named arguments' => [new UserTotpCode(message: 'myMessage', translationDomain: 'myDomain')];
     }
 
+    #[Test]
     #[DataProvider('emptyTotpCodeData')]
-    public function testEmptyTotpCodesAreNotValid(string|null $code): void
+    public function validate_emptyCode_raisedViolation(string|null $code): void
     {
         $constraint = new UserTotpCode(['message' => 'myMessage']);
 
@@ -103,8 +107,10 @@ class UserTotpCodeValidatorTest extends ConstraintValidatorTestCase
         ];
     }
 
-    public function testUserIsNotValid(): void
+    #[Test]
+    public function validate_invalidUser_throwsException(): void
     {
+        // Create a user that doesn't implement TwoFactorInterface
         $user = $this->createMock(UserInterface::class);
 
         $this->tokenStorage = $this->createTokenStorage($user);
@@ -127,7 +133,7 @@ class UserTotpCodeValidatorTest extends ConstraintValidatorTestCase
 
         $mock = $this->createMock(UserWithTwoFactorInterface::class);
         $mock
-            ->expects(self::any())
+            ->expects($this->any())
             ->method('getTotpAuthenticationConfiguration')
             ->willReturn($configuration);
 
@@ -145,7 +151,7 @@ class UserTotpCodeValidatorTest extends ConstraintValidatorTestCase
 
         $mock = $this->createMock(TokenStorageInterface::class);
         $mock
-            ->expects(self::any())
+            ->expects($this->any())
             ->method('getToken')
             ->willReturn($token);
 
@@ -156,7 +162,7 @@ class UserTotpCodeValidatorTest extends ConstraintValidatorTestCase
     {
         $mock = $this->createMock(TokenInterface::class);
         $mock
-            ->expects(self::any())
+            ->expects($this->any())
             ->method('getUser')
             ->willReturn($user);
 

--- a/tests/Security/TwoFactor/Validator/Constraints/UserTotpCodeValidatorTest.php
+++ b/tests/Security/TwoFactor/Validator/Constraints/UserTotpCodeValidatorTest.php
@@ -24,8 +24,8 @@ use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
  */
 class UserTotpCodeValidatorTest extends ConstraintValidatorTestCase
 {
-    protected TokenStorageInterface $tokenStorage;
-    protected TotpAuthenticatorInterface&MockObject $totpAuthenticator;
+    private TokenStorageInterface $tokenStorage;
+    private TotpAuthenticatorInterface&MockObject $totpAuthenticator;
 
     protected function createValidator(): UserTotpCodeValidator
     {
@@ -122,12 +122,12 @@ class UserTotpCodeValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate('secret', new UserTotpCode());
     }
 
-    protected function createTotpConfiguration(): TotpConfigurationInterface
+    private function createTotpConfiguration(): TotpConfigurationInterface
     {
         return $this->createMock(TotpConfigurationInterface::class);
     }
 
-    protected function createUser(): UserWithTwoFactorInterface
+    private function createUser(): UserWithTwoFactorInterface
     {
         $configuration = $this->createTotpConfiguration();
 
@@ -140,12 +140,12 @@ class UserTotpCodeValidatorTest extends ConstraintValidatorTestCase
         return $mock;
     }
 
-    protected function createTotpAuthenticator(): TotpAuthenticatorInterface&MockObject
+    private function createTotpAuthenticator(): TotpAuthenticatorInterface&MockObject
     {
         return $this->createMock(TotpAuthenticatorInterface::class);
     }
 
-    protected function createTokenStorage(UserInterface|null $user = null): TokenStorageInterface
+    private function createTokenStorage(UserInterface|null $user = null): TokenStorageInterface
     {
         $token = $this->createAuthenticationToken($user);
 
@@ -158,7 +158,7 @@ class UserTotpCodeValidatorTest extends ConstraintValidatorTestCase
         return $mock;
     }
 
-    protected function createAuthenticationToken(UserInterface|null $user = null): TokenInterface
+    private function createAuthenticationToken(UserInterface|null $user = null): TokenInterface
     {
         $mock = $this->createMock(TokenInterface::class);
         $mock

--- a/tests/Security/TwoFactor/Validator/Constraints/UserTotpCodeValidatorTest.php
+++ b/tests/Security/TwoFactor/Validator/Constraints/UserTotpCodeValidatorTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scheb\TwoFactorBundle\Tests\Security\TwoFactor\Validator\Constraints;
+
+use Generator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use Scheb\TwoFactorBundle\Model\Totp\TotpConfigurationInterface;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\Totp\TotpAuthenticatorInterface;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Validator\Constraints\UserTotpCode;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Validator\Constraints\UserTotpCodeValidator;
+use Scheb\TwoFactorBundle\Tests\Security\TwoFactor\Provider\Totp\UserWithTwoFactorInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+/**
+ * @implements ConstraintValidatorTestCase<UserTotpCodeValidator>
+ */
+class UserTotpCodeValidatorTest extends ConstraintValidatorTestCase
+{
+    protected TokenStorageInterface $tokenStorage;
+    protected TotpAuthenticatorInterface&MockObject $totpAuthenticator;
+
+    protected function createValidator(): UserTotpCodeValidator
+    {
+        return new UserTotpCodeValidator($this->tokenStorage, $this->totpAuthenticator);
+    }
+
+    protected function setUp(): void
+    {
+        $user = $this->createUser();
+        $this->tokenStorage = $this->createTokenStorage($user);
+        $this->totpAuthenticator = $this->createTotpAuthenticator();
+
+        parent::setUp();
+    }
+
+    #[DataProvider('provideConstraints')]
+    public function testTotpCodeIsValid(UserTotpCode $constraint): void
+    {
+        $this->totpAuthenticator
+            ->expects(self::any())
+            ->method('checkCode')
+            ->willReturn(true);
+
+        $this->validator->validate('secret', $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    #[DataProvider('provideConstraints')]
+    public function testTotpCodeIsNotValid(UserTotpCode $constraint): void
+    {
+        $this->totpAuthenticator
+            ->expects(self::any())
+            ->method('checkCode')
+            ->willReturn(false);
+
+        $this->validator->validate('secret', $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setCode(UserTotpCode::INVALID_TOTP_CODE_ERROR)
+            ->setTranslationDomain('myDomain')
+            ->assertRaised();
+    }
+
+    /**
+     * @return Generator<string, list{UserTotpCode}>
+     */
+    public static function provideConstraints(): iterable
+    {
+        yield 'Doctrine style' => [new UserTotpCode(['message' => 'myMessage', 'translationDomain' => 'myDomain'])];
+
+        yield 'named arguments' => [new UserTotpCode(message: 'myMessage', translationDomain: 'myDomain')];
+    }
+
+    #[DataProvider('emptyTotpCodeData')]
+    public function testEmptyTotpCodesAreNotValid(string|null $code): void
+    {
+        $constraint = new UserTotpCode(['message' => 'myMessage']);
+
+        $this->validator->validate($code, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setCode(UserTotpCode::INVALID_TOTP_CODE_ERROR)
+            ->setTranslationDomain('myDomain')
+            ->assertRaised();
+    }
+
+    /**
+     * @return list<array{string|null}>
+     */
+    public static function emptyTotpCodeData(): array
+    {
+        return [
+            [null],
+            [''],
+        ];
+    }
+
+    public function testUserIsNotValid(): void
+    {
+        $user = $this->createMock(UserInterface::class);
+
+        $this->tokenStorage = $this->createTokenStorage($user);
+        $this->validator = $this->createValidator();
+        $this->validator->initialize($this->context);
+
+        $this->expectException(ConstraintDefinitionException::class);
+
+        $this->validator->validate('secret', new UserTotpCode());
+    }
+
+    protected function createTotpConfiguration(): TotpConfigurationInterface
+    {
+        return $this->createMock(TotpConfigurationInterface::class);
+    }
+
+    protected function createUser(): UserWithTwoFactorInterface
+    {
+        $configuration = $this->createTotpConfiguration();
+
+        $mock = $this->createMock(UserWithTwoFactorInterface::class);
+        $mock
+            ->expects(self::any())
+            ->method('getTotpAuthenticationConfiguration')
+            ->willReturn($configuration);
+
+        return $mock;
+    }
+
+    protected function createTotpAuthenticator(): TotpAuthenticatorInterface&MockObject
+    {
+        return $this->createMock(TotpAuthenticatorInterface::class);
+    }
+
+    protected function createTokenStorage(UserInterface|null $user = null): TokenStorageInterface
+    {
+        $token = $this->createAuthenticationToken($user);
+
+        $mock = $this->createMock(TokenStorageInterface::class);
+        $mock
+            ->expects(self::any())
+            ->method('getToken')
+            ->willReturn($token);
+
+        return $mock;
+    }
+
+    protected function createAuthenticationToken(UserInterface|null $user = null): TokenInterface
+    {
+        $mock = $this->createMock(TokenInterface::class);
+        $mock
+            ->expects(self::any())
+            ->method('getUser')
+            ->willReturn($user);
+
+        return $mock;
+    }
+}


### PR DESCRIPTION
<!--
👍🎉 First off, thanks for taking the time to contribute! 🎉👍

Here are some tips for you:
 - Please follow the PR contribution guidelines: https://github.com/scheb/2fa/blob/7.x/CONTRIBUTING.md#creating-a-pull-request
 - Don't break backwards compatibility. If you have to, let's discuss! :)
 - Always add/update tests and ensure the build passes
-->

**Description**
<!--
Please provide a clear and concise description of the change.

For bug fixes:
 - What problem does the PR solve?
 - If this fixes an open issue, please link the bug ticket

For new features:
 - What's the motivation for this change? What's the problem you're trying to solve?
 - Why do you think it's a good idea to solve it this way?
-->
Add a Symfony validator constraint to check the user's TOTP code. Based on the [`UserPassword`](https://symfony.com/doc/current/reference/constraints/UserPassword.html) constraint from Symfony.

This allows developers to integrate a TOTP check in Symfony forms without having to manually validate the code (including the setup form when first activating TOTP for the account), simply by adding the `UserTotpCode` constraint to the Symfony form, the entity (as an attribute) or by calling the Symfony validator itself.

I only a created it for TOTP because that's what I'm using in a project, but I'm willing to help build it for other 2FA authentication methods if this one gets accepted.
