### PR TITLE
use implementation for backup code manager interface

### DIFF
--- a/src/bundle/Resources/config/backup_codes.php
+++ b/src/bundle/Resources/config/backup_codes.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Scheb\TwoFactorBundle\Security\Http\EventListener\CheckBackupCodeListener;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Backup\BackupCodeManager;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Backup\BackupCodeManagerInterface;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Backup\NullBackupCodeManager;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
@@ -21,5 +22,7 @@ return static function (ContainerConfigurator $container): void {
                 service('scheb_two_factor.provider_preparation_recorder'),
                 service('scheb_two_factor.backup_code_manager'),
                 service('event_dispatcher'),
-            ]);
+            ])
+
+        ->alias(BackupCodeManagerInterface::class, 'scheb_two_factor.default_backup_code_manager');
 };


### PR DESCRIPTION
<!--
👍🎉 First off, thanks for taking the time to contribute! 🎉👍

Here are some tips for you:
 - Please follow the PR contribution guidelines: https://github.com/scheb/2fa/blob/8.x/CONTRIBUTING.md#creating-a-pull-request
 - Don't break backwards compatibility. If you have to, let's discuss! :)
 - Always add/update tests and ensure the build passes
-->

**Description**
This allows to use the `BackupCodeManagerInterface` and will get the "default" implementation using the symfony bundle.