### PR TITLE
Fix version number (v8) in installation instructions

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -4,7 +4,7 @@ Installation
 Prerequisites
 -------------
 
-You're currently looking at the documentation of **SchebTwoFactorBundle version 7**. This bundle version is
+You're currently looking at the documentation of **SchebTwoFactorBundle version 8**. This bundle version is
 **compatible with Symfony 7.4 or Symfony 8.x**.
 
 If you're using anything other than Doctrine ORM to manage the user entity you will have to implement a


### PR DESCRIPTION
Thanks for the great job. This tiny MR only fixes the version number in installation instructions for v8.x.