### PR TITLE
fix: stateless 2fa provider preparation listener

### DIFF
--- a/src/bundle/Resources/config/security.php
+++ b/src/bundle/Resources/config/security.php
@@ -87,6 +87,7 @@ return static function (ContainerConfigurator $container): void {
             ->tag('kernel.event_subscriber')
 
         ->set('scheb_two_factor.security.provider_preparation_listener', TwoFactorProviderPreparationListener::class)
+            ->tag('kernel.reset', ['method' => 'reset'])
             ->args([
                 service('scheb_two_factor.provider_registry'),
                 service('scheb_two_factor.provider_preparation_recorder'),

--- a/src/bundle/Security/TwoFactor/Provider/TwoFactorProviderPreparationListener.php
+++ b/src/bundle/Security/TwoFactor/Provider/TwoFactorProviderPreparationListener.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\AuthenticationEvents;
 use Symfony\Component\Security\Core\Event\AuthenticationEvent;
+use Symfony\Contracts\Service\ResetInterface;
 use function assert;
 use function sprintf;
 use const PHP_INT_MAX;
@@ -23,7 +24,7 @@ use const PHP_INT_MAX;
 /**
  * @final
  */
-class TwoFactorProviderPreparationListener implements EventSubscriberInterface
+class TwoFactorProviderPreparationListener implements EventSubscriberInterface, ResetInterface
 {
     // This must trigger very first, followed by AuthenticationSuccessEventSuppressor
     public const int AUTHENTICATION_SUCCESS_LISTENER_PRIORITY = PHP_INT_MAX;
@@ -135,5 +136,10 @@ class TwoFactorProviderPreparationListener implements EventSubscriberInterface
             TwoFactorAuthenticationEvents::FORM => 'onTwoFactorForm',
             KernelEvents::RESPONSE => ['onKernelResponse', self::RESPONSE_LISTENER_PRIORITY],
         ];
+    }
+
+    public function reset(): void
+    {
+        $this->twoFactorToken = null;
     }
 }

--- a/tests/Security/TwoFactor/Provider/TwoFactorProviderPreparationListenerTest.php
+++ b/tests/Security/TwoFactor/Provider/TwoFactorProviderPreparationListenerTest.php
@@ -230,4 +230,19 @@ class TwoFactorProviderPreparationListenerTest extends TestCase
         $this->listener->onTwoFactorForm($event);
         $this->listener->onKernelResponse($this->createResponseEvent());
     }
+
+    #[Test]
+    public function reset_tokenPreviouslySetted_resetToken(): void
+    {
+        $this->initTwoFactorProviderPreparationListener(true, false);
+        $event = $this->createAuthenticationEvent();
+
+        $this->expectNotPrepareCurrentProvider();
+
+        $this->listener->onLogin($event);
+
+        $this->listener->reset();
+
+        $this->listener->onKernelResponse($this->createResponseEvent());
+    }
 }


### PR DESCRIPTION
<!--
👍🎉 First off, thanks for taking the time to contribute! 🎉👍

Here are some tips for you:
 - Please follow the PR contribution guidelines: https://github.com/scheb/2fa/blob/8.x/CONTRIBUTING.md#creating-a-pull-request
 - Don't break backwards compatibility. If you have to, let's discuss! :)
 - Always add/update tests and ensure the build passes
-->

**Description**
In certain scenarios, TwoFactorProviderPreparationListener might not be re-instanciated between requests. 
That's the case when multiple requests are handled by a single worker, like when serving the application with RoadRunner or with FrankenPHP. 
In that case, the twoFactorToken value might leak from a request to another, leading to unwanted preparations.
By implementing ResetInterface, the token is now properly reseted between requests