### PR TITLE
feat(api): expose ProviderRegistry and ConditionRegistry with an interface

### DIFF
--- a/src/bundle/Controller/FormController.php
+++ b/src/bundle/Controller/FormController.php
@@ -6,7 +6,7 @@ namespace Scheb\TwoFactorBundle\Controller;
 
 use Scheb\TwoFactorBundle\Security\Authentication\Token\TwoFactorTokenInterface;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\Exception\UnknownTwoFactorProviderException;
-use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderRegistry;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderRegistryInterface;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Trusted\TrustedDeviceManagerInterface;
 use Scheb\TwoFactorBundle\Security\TwoFactor\TwoFactorFirewallConfig;
 use Scheb\TwoFactorBundle\Security\TwoFactor\TwoFactorFirewallContext;
@@ -28,7 +28,7 @@ class FormController
 {
     public function __construct(
         private readonly TokenStorageInterface $tokenStorage,
-        private readonly TwoFactorProviderRegistry $providerRegistry,
+        private readonly TwoFactorProviderRegistryInterface $providerRegistry,
         private readonly TwoFactorFirewallContext $twoFactorFirewallContext,
         private readonly LogoutUrlGenerator $logoutUrlGenerator,
         private readonly TrustedDeviceManagerInterface|null $trustedDeviceManager,

--- a/src/bundle/Security/Http/EventListener/CheckTwoFactorCodeListener.php
+++ b/src/bundle/Security/Http/EventListener/CheckTwoFactorCodeListener.php
@@ -10,7 +10,7 @@ use Scheb\TwoFactorBundle\Security\Authentication\Exception\TwoFactorProviderNot
 use Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorAuthenticationEvents;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorCodeEvent;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\PreparationRecorderInterface;
-use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderRegistry;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderRegistryInterface;
 use Symfony\Component\Security\Http\Event\CheckPassportEvent;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
@@ -23,7 +23,7 @@ class CheckTwoFactorCodeListener extends AbstractCheckCodeListener
 
     public function __construct(
         PreparationRecorderInterface $preparationRecorder,
-        private readonly TwoFactorProviderRegistry $providerRegistry,
+        private readonly TwoFactorProviderRegistryInterface $providerRegistry,
         private readonly EventDispatcherInterface $eventDispatcher,
     ) {
         parent::__construct($preparationRecorder);

--- a/src/bundle/Security/TwoFactor/Condition/TwoFactorConditionRegistry.php
+++ b/src/bundle/Security/TwoFactor/Condition/TwoFactorConditionRegistry.php
@@ -9,7 +9,7 @@ use Scheb\TwoFactorBundle\Security\TwoFactor\AuthenticationContextInterface;
 /**
  * @final
  */
-class TwoFactorConditionRegistry
+class TwoFactorConditionRegistry implements TwoFactorConditionRegistryInterface
 {
     /**
      * @param TwoFactorConditionInterface[] $conditions

--- a/src/bundle/Security/TwoFactor/Condition/TwoFactorConditionRegistryInterface.php
+++ b/src/bundle/Security/TwoFactor/Condition/TwoFactorConditionRegistryInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scheb\TwoFactorBundle\Security\TwoFactor\Condition;
+
+use Scheb\TwoFactorBundle\Security\TwoFactor\AuthenticationContextInterface;
+
+interface TwoFactorConditionRegistryInterface
+{
+    public function shouldPerformTwoFactorAuthentication(AuthenticationContextInterface $context): bool;
+}

--- a/src/bundle/Security/TwoFactor/Event/AuthenticationTokenListener.php
+++ b/src/bundle/Security/TwoFactor/Event/AuthenticationTokenListener.php
@@ -8,7 +8,7 @@ use RuntimeException;
 use Scheb\TwoFactorBundle\Security\Authentication\Token\TwoFactorTokenInterface;
 use Scheb\TwoFactorBundle\Security\Http\Authenticator\TwoFactorAuthenticator;
 use Scheb\TwoFactorBundle\Security\TwoFactor\AuthenticationContextFactoryInterface;
-use Scheb\TwoFactorBundle\Security\TwoFactor\Condition\TwoFactorConditionRegistry;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Condition\TwoFactorConditionRegistryInterface;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderInitiator;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -22,7 +22,7 @@ class AuthenticationTokenListener implements EventSubscriberInterface
 {
     public function __construct(
         private readonly string $firewallName,
-        private readonly TwoFactorConditionRegistry $twoFactorConditionRegistry,
+        private readonly TwoFactorConditionRegistryInterface $twoFactorConditionRegistry,
         private readonly TwoFactorProviderInitiator $twoFactorProviderInitiator,
         private readonly AuthenticationContextFactoryInterface $authenticationContextFactory,
         private readonly RequestStack $requestStack,

--- a/src/bundle/Security/TwoFactor/Provider/TwoFactorProviderInitiator.php
+++ b/src/bundle/Security/TwoFactor/Provider/TwoFactorProviderInitiator.php
@@ -20,7 +20,7 @@ use const E_USER_DEPRECATED;
 class TwoFactorProviderInitiator
 {
     public function __construct(
-        private readonly TwoFactorProviderRegistry $providerRegistry,
+        private readonly TwoFactorProviderRegistryInterface $providerRegistry,
         private readonly TwoFactorTokenFactoryInterface $twoFactorTokenFactory,
         private readonly TwoFactorProviderDeciderInterface $twoFactorProviderDecider,
     ) {

--- a/src/bundle/Security/TwoFactor/Provider/TwoFactorProviderPreparationListener.php
+++ b/src/bundle/Security/TwoFactor/Provider/TwoFactorProviderPreparationListener.php
@@ -36,7 +36,7 @@ class TwoFactorProviderPreparationListener implements EventSubscriberInterface, 
     private readonly LoggerInterface $logger;
 
     public function __construct(
-        private readonly TwoFactorProviderRegistry $providerRegistry,
+        private readonly TwoFactorProviderRegistryInterface $providerRegistry,
         private readonly PreparationRecorderInterface $preparationRecorder,
         LoggerInterface|null $logger,
         private readonly string $firewallName,

--- a/src/bundle/Security/TwoFactor/Provider/TwoFactorProviderRegistry.php
+++ b/src/bundle/Security/TwoFactor/Provider/TwoFactorProviderRegistry.php
@@ -10,7 +10,7 @@ use function sprintf;
 /**
  * @final
  */
-class TwoFactorProviderRegistry
+class TwoFactorProviderRegistry implements TwoFactorProviderRegistryInterface
 {
     /**
      * @param iterable<string,TwoFactorProviderInterface> $providers
@@ -20,7 +20,7 @@ class TwoFactorProviderRegistry
     }
 
     /**
-     * @return iterable<string,TwoFactorProviderInterface>
+     * {@inheritDoc}
      */
     public function getAllProviders(): iterable
     {

--- a/src/bundle/Security/TwoFactor/Provider/TwoFactorProviderRegistryInterface.php
+++ b/src/bundle/Security/TwoFactor/Provider/TwoFactorProviderRegistryInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scheb\TwoFactorBundle\Security\TwoFactor\Provider;
+
+interface TwoFactorProviderRegistryInterface
+{
+    /**
+     * @return iterable<string,TwoFactorProviderInterface>
+     */
+    public function getAllProviders(): iterable;
+
+    public function getProvider(string $providerName): TwoFactorProviderInterface;
+}

--- a/tests/Controller/FormControllerTest.php
+++ b/tests/Controller/FormControllerTest.php
@@ -12,7 +12,7 @@ use Scheb\TwoFactorBundle\Security\Authentication\Exception\TwoFactorProviderNot
 use Scheb\TwoFactorBundle\Security\Authentication\Token\TwoFactorTokenInterface;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorFormRendererInterface;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderInterface;
-use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderRegistry;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderRegistryInterface;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Trusted\TrustedDeviceManagerInterface;
 use Scheb\TwoFactorBundle\Security\TwoFactor\TwoFactorFirewallConfig;
 use Scheb\TwoFactorBundle\Security\TwoFactor\TwoFactorFirewallContext;
@@ -38,7 +38,7 @@ class FormControllerTest extends TestCase
     private const string LOGOUT_PATH = '/logout';
 
     private MockObject&TokenStorageInterface $tokenStorage;
-    private MockObject&TwoFactorProviderRegistry $providerRegistry;
+    private MockObject&TwoFactorProviderRegistryInterface $providerRegistry;
     private MockObject&SessionInterface $session;
     private MockObject&Request $request;
     private MockObject&TwoFactorFormRendererInterface $formRenderer;
@@ -68,7 +68,7 @@ class FormControllerTest extends TestCase
 
         $this->tokenStorage = $this->createMock(TokenStorageInterface::class);
 
-        $this->providerRegistry = $this->createMock(TwoFactorProviderRegistry::class);
+        $this->providerRegistry = $this->createMock(TwoFactorProviderRegistryInterface::class);
         $this->providerRegistry
             ->expects($this->any())
             ->method('getProvider')

--- a/tests/Security/Http/EventListener/CheckTwoFactorCodeListenerTest.php
+++ b/tests/Security/Http/EventListener/CheckTwoFactorCodeListenerTest.php
@@ -13,7 +13,7 @@ use Scheb\TwoFactorBundle\Security\Http\EventListener\CheckTwoFactorCodeListener
 use Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorAuthenticationEvents;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorCodeEvent;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderInterface;
-use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderRegistry;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderRegistryInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -21,14 +21,14 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
  */
 class CheckTwoFactorCodeListenerTest extends AbstractCheckCodeListenerTestSetup
 {
-    private MockObject&TwoFactorProviderRegistry $providerRegistry;
+    private MockObject&TwoFactorProviderRegistryInterface $providerRegistry;
     private MockObject&EventDispatcherInterface $eventDispatcher;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->providerRegistry = $this->createMock(TwoFactorProviderRegistry::class);
+        $this->providerRegistry = $this->createMock(TwoFactorProviderRegistryInterface::class);
         $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
         $this->listener = new CheckTwoFactorCodeListener(
             $this->preparationRecorder,

--- a/tests/Security/TwoFactor/Event/AuthenticationTokenListenerTest.php
+++ b/tests/Security/TwoFactor/Event/AuthenticationTokenListenerTest.php
@@ -10,7 +10,7 @@ use Scheb\TwoFactorBundle\Security\Authentication\Token\TwoFactorTokenInterface;
 use Scheb\TwoFactorBundle\Security\Http\Authenticator\TwoFactorAuthenticator;
 use Scheb\TwoFactorBundle\Security\TwoFactor\AuthenticationContextFactoryInterface;
 use Scheb\TwoFactorBundle\Security\TwoFactor\AuthenticationContextInterface;
-use Scheb\TwoFactorBundle\Security\TwoFactor\Condition\TwoFactorConditionRegistry;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Condition\TwoFactorConditionRegistryInterface;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Event\AuthenticationTokenListener;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderInitiator;
 use Scheb\TwoFactorBundle\Tests\TestCase;
@@ -24,14 +24,14 @@ class AuthenticationTokenListenerTest extends TestCase
 {
     private const string FIREWALL_NAME = 'firewallName';
 
-    private MockObject&TwoFactorConditionRegistry $twoFactorConditionRegistry;
+    private MockObject&TwoFactorConditionRegistryInterface $twoFactorConditionRegistry;
     private MockObject&TwoFactorProviderInitiator $twoFactorProviderInitiator;
     private MockObject&AuthenticationContextFactoryInterface $authenticationContextFactory;
     private AuthenticationTokenListener $listener;
 
     protected function setUp(): void
     {
-        $this->twoFactorConditionRegistry = $this->createMock(TwoFactorConditionRegistry::class);
+        $this->twoFactorConditionRegistry = $this->createMock(TwoFactorConditionRegistryInterface::class);
         $this->twoFactorProviderInitiator = $this->createMock(TwoFactorProviderInitiator::class);
         $this->authenticationContextFactory = $this->createMock(AuthenticationContextFactoryInterface::class);
 

--- a/tests/Security/TwoFactor/Provider/TwoFactorProviderInitiatorTest.php
+++ b/tests/Security/TwoFactor/Provider/TwoFactorProviderInitiatorTest.php
@@ -12,7 +12,7 @@ use Scheb\TwoFactorBundle\Security\Authentication\Token\TwoFactorTokenInterface;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderDeciderInterface;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderInitiator;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderInterface;
-use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderRegistry;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderRegistryInterface;
 use Scheb\TwoFactorBundle\Tests\Security\TwoFactor\Condition\AbstractAuthenticationContextTestCase;
 
 class TwoFactorProviderInitiatorTest extends AbstractAuthenticationContextTestCase
@@ -40,7 +40,7 @@ class TwoFactorProviderInitiatorTest extends AbstractAuthenticationContextTestCa
 
         $this->withoutNeedsPreparationProvider = $this->createMock(TwoFactorProviderInterface::class);
 
-        $providerRegistry = $this->createMock(TwoFactorProviderRegistry::class);
+        $providerRegistry = $this->createMock(TwoFactorProviderRegistryInterface::class);
         $providerRegistry
             ->expects($this->any())
             ->method('getAllProviders')

--- a/tests/Security/TwoFactor/Provider/TwoFactorProviderPreparationListenerTest.php
+++ b/tests/Security/TwoFactor/Provider/TwoFactorProviderPreparationListenerTest.php
@@ -13,7 +13,7 @@ use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\Exception\UnexpectedTokenE
 use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\PreparationRecorderInterface;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderInterface;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderPreparationListener;
-use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderRegistry;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderRegistryInterface;
 use Scheb\TwoFactorBundle\Tests\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -27,7 +27,7 @@ class TwoFactorProviderPreparationListenerTest extends TestCase
     private const string FIREWALL_NAME = 'firewallName';
     private const string CURRENT_PROVIDER_NAME = 'currentProviderName';
 
-    private MockObject&TwoFactorProviderRegistry $providerRegistry;
+    private MockObject&TwoFactorProviderRegistryInterface $providerRegistry;
     private MockObject&Request $request;
     private MockObject&PreparationRecorderInterface $preparationRecorder;
     private MockObject&TwoFactorToken $token;
@@ -54,7 +54,7 @@ class TwoFactorProviderPreparationListenerTest extends TestCase
 
         $this->preparationRecorder = $this->createMock(PreparationRecorderInterface::class);
 
-        $this->providerRegistry = $this->createMock(TwoFactorProviderRegistry::class);
+        $this->providerRegistry = $this->createMock(TwoFactorProviderRegistryInterface::class);
     }
 
     private function initTwoFactorProviderPreparationListener(bool $prepareOnLogin, bool $prepareOnAccessDenied): void


### PR DESCRIPTION
**Description**

This Pull Request adds `TwoFactorProviderRegistryInterface` and `TwoFactorConditionRegistryInterface`, and expose the underlying classes to the rest of the code using those interface.

The purpose is to allow a rewrite ; or a decoration of the logic underneath, unlocking more customization possibilities.

One example: in my codebase, I need to know when 2fa is enabled on a User, but skipped because of a condition. 
This is easy when decorating `TwoFactorConditionRegistry` ; but because of the lack of interface, I must extends a `@final` class. It's possible, but not recommended.
