### PR TITLE
Close #213: honor post-success listeners that may block authentication

### DIFF
--- a/src/bundle/Security/Http/Authenticator/TwoFactorAuthenticator.php
+++ b/src/bundle/Security/Http/Authenticator/TwoFactorAuthenticator.php
@@ -29,17 +29,22 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Badge\RememberMeBadge
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\Service\ResetInterface;
 use function assert;
 use function class_exists;
+use function count;
+use function spl_object_hash;
 
 /**
  * @final
  */
-class TwoFactorAuthenticator implements AuthenticatorInterface, InteractiveAuthenticatorInterface
+class TwoFactorAuthenticator implements AuthenticatorInterface, InteractiveAuthenticatorInterface, ResetInterface
 {
     public const FLAG_2FA_COMPLETE = '2fa_complete';
 
     private readonly LoggerInterface $logger;
+    /** @var TwoFactorTokenInterface[] */
+    private array $onCompleteTokens = [];
 
     public function __construct(
         private readonly TwoFactorFirewallConfig $twoFactorFirewallConfig,
@@ -51,6 +56,11 @@ class TwoFactorAuthenticator implements AuthenticatorInterface, InteractiveAuthe
         LoggerInterface|null $logger = null,
     ) {
         $this->logger = $logger ?? new NullLogger();
+    }
+
+    public function reset(): void
+    {
+        $this->onCompleteTokens = [];
     }
 
     public function supports(Request $request): bool|null
@@ -113,6 +123,7 @@ class TwoFactorAuthenticator implements AuthenticatorInterface, InteractiveAuthe
         if ($this->isAuthenticationComplete($twoFactorToken)) {
             $authenticatedToken = $twoFactorToken->getAuthenticatedToken(); // Authentication complete, unwrap the token
             $authenticatedToken->setAttribute(self::FLAG_2FA_COMPLETE, true);
+            $this->onCompleteTokens[spl_object_hash($authenticatedToken)] = $twoFactorToken;
 
             return $authenticatedToken;
         }
@@ -122,7 +133,10 @@ class TwoFactorAuthenticator implements AuthenticatorInterface, InteractiveAuthe
 
     private function isAuthenticationComplete(TwoFactorTokenInterface $token): bool
     {
-        return !$this->twoFactorFirewallConfig->isMultiFactor() || $token->allTwoFactorProvidersAuthenticated();
+        return !$this->twoFactorFirewallConfig->isMultiFactor()
+            || $token->allTwoFactorProvidersAuthenticated()
+            // The current provider is the last provider. It will be completed in onAuthenticationSuccess.
+            || 1 === count($token->getTwoFactorProviders());
     }
 
     public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): Response|null
@@ -132,9 +146,23 @@ class TwoFactorAuthenticator implements AuthenticatorInterface, InteractiveAuthe
 
         // When it's still a TwoFactorTokenInterface, keep showing the auth form
         if ($token instanceof TwoFactorTokenInterface) {
+            $currentProvider = $token->getCurrentTwoFactorProvider();
+            if (null !== $currentProvider) {
+                $token->setTwoFactorProviderComplete($currentProvider);
+            }
+
             $this->dispatchTwoFactorAuthenticationEvent(TwoFactorAuthenticationEvents::REQUIRE, $request, $token);
 
             return $this->authenticationRequiredHandler->onAuthenticationRequired($request, $token);
+        }
+
+        $twoFactorToken = $this->onCompleteTokens[spl_object_hash($token)] ?? null;
+        if (null !== $twoFactorToken) {
+            unset($this->onCompleteTokens[spl_object_hash($token)]);
+            $currentProvider = $twoFactorToken->getCurrentTwoFactorProvider();
+            if (null !== $currentProvider) {
+                $twoFactorToken->setTwoFactorProviderComplete($currentProvider);
+            }
         }
 
         $this->dispatchTwoFactorAuthenticationEvent(TwoFactorAuthenticationEvents::COMPLETE, $request, $token);

--- a/src/bundle/Security/Http/Authenticator/TwoFactorAuthenticator.php
+++ b/src/bundle/Security/Http/Authenticator/TwoFactorAuthenticator.php
@@ -123,6 +123,9 @@ class TwoFactorAuthenticator implements AuthenticatorInterface, InteractiveAuthe
         if ($this->isAuthenticationComplete($twoFactorToken)) {
             $authenticatedToken = $twoFactorToken->getAuthenticatedToken(); // Authentication complete, unwrap the token
             $authenticatedToken->setAttribute(self::FLAG_2FA_COMPLETE, true);
+
+            // Backwards compatibility for bundle version <=8
+            // Remember the token to set the provider complete in onAuthenticationSuccess
             $this->onCompleteTokens[spl_object_hash($authenticatedToken)] = $twoFactorToken;
 
             return $authenticatedToken;
@@ -156,13 +159,17 @@ class TwoFactorAuthenticator implements AuthenticatorInterface, InteractiveAuthe
             return $this->authenticationRequiredHandler->onAuthenticationRequired($request, $token);
         }
 
+        // Backwards compatibility for bundle version <=8
+        // In case the two-factor process was completed, $token is no longer a TwoFactorToken
+        // Set the provider completed on the remembered TwoFactorToken
         $twoFactorToken = $this->onCompleteTokens[spl_object_hash($token)] ?? null;
         if (null !== $twoFactorToken) {
-            unset($this->onCompleteTokens[spl_object_hash($token)]);
             $currentProvider = $twoFactorToken->getCurrentTwoFactorProvider();
             if (null !== $currentProvider) {
                 $twoFactorToken->setTwoFactorProviderComplete($currentProvider);
             }
+
+            unset($this->onCompleteTokens[spl_object_hash($token)]);
         }
 
         $this->dispatchTwoFactorAuthenticationEvent(TwoFactorAuthenticationEvents::COMPLETE, $request, $token);

--- a/src/bundle/Security/Http/EventListener/AbstractCheckCodeListener.php
+++ b/src/bundle/Security/Http/EventListener/AbstractCheckCodeListener.php
@@ -50,7 +50,7 @@ abstract class AbstractCheckCodeListener implements EventSubscriberInterface
             return;
         }
 
-        $token->setTwoFactorProviderComplete($providerName);
+        // Badge is resolved, but authentication for provider is not complete yet
         $credentialsBadge->markResolved();
     }
 

--- a/tests/Security/Http/Authenticator/TwoFactorAuthenticatorTest.php
+++ b/tests/Security/Http/Authenticator/TwoFactorAuthenticatorTest.php
@@ -30,8 +30,10 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Badge\CsrfTokenBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\RememberMeBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use function array_values;
 use function assert;
 use function method_exists;
+use function reset;
 
 class TwoFactorAuthenticatorTest extends TestCase
 {
@@ -196,9 +198,36 @@ class TwoFactorAuthenticatorTest extends TestCase
     private function expect2faCompleteFlagSet(MockObject $authenticatedToken): void
     {
         $authenticatedToken
-            ->expects($this->any())
+            ->expects($this->atLeastOnce())
             ->method('setAttribute')
             ->with(TwoFactorAuthenticator::FLAG_2FA_COMPLETE, true);
+    }
+
+    /** @param string[] $providerNames */
+    private function stubTwoFactorTokenProviders(MockObject&TwoFactorTokenInterface $twoFactorToken, array $providerNames): void
+    {
+        $twoFactorToken
+            ->expects($this->any())
+            ->method('getTwoFactorProviders')
+            ->willReturnCallback(static function () use (&$providerNames) {
+                return array_values($providerNames);
+            });
+        $twoFactorToken
+            ->method('getCurrentTwoFactorProvider')
+            ->willReturnCallback(static function () use (&$providerNames): string|null {
+                return empty($providerNames) ? null : reset($providerNames);
+            });
+        $twoFactorToken
+            ->method('setTwoFactorProviderComplete')
+            ->willReturnCallback(static function (string $provider) use (&$providerNames): void {
+                foreach ($providerNames as $i => $providerName) {
+                    if ($providerName !== $provider) {
+                        continue;
+                    }
+
+                    unset($providerNames[$i]);
+                }
+            });
     }
 
     #[Test]
@@ -375,7 +404,12 @@ class TwoFactorAuthenticatorTest extends TestCase
             [$this->isInstanceOf(TwoFactorAuthenticationEvent::class), TwoFactorAuthenticationEvents::REQUIRE],
         ]);
 
-        $this->authenticator->onAuthenticationSuccess($this->request, $this->createTwoFactorToken(), self::FIREWALL_NAME);
+        $passport = $this->createPassportWithTwoFactorCredentials($token = $this->createTwoFactorToken());
+        $this->stubTwoFactorTokenProviders($token, ['totp', 'email']);
+
+        $this->authenticator->reset();
+        $this->authenticator->createToken($passport, self::FIREWALL_NAME);
+        $this->authenticator->onAuthenticationSuccess($this->request, $token, self::FIREWALL_NAME);
     }
 
     #[Test]
@@ -402,7 +436,18 @@ class TwoFactorAuthenticatorTest extends TestCase
             [$this->isInstanceOf(TwoFactorAuthenticationEvent::class), TwoFactorAuthenticationEvents::COMPLETE],
         ]);
 
-        $this->authenticator->onAuthenticationSuccess($this->request, $this->createMock(TokenInterface::class), self::FIREWALL_NAME);
+        $passport = $this->createPassportWithTwoFactorCredentials($token = $this->createTwoFactorToken());
+        $token
+            ->method('getCurrentTwoFactorProvider')
+            ->willReturn('totp');
+        $token
+            ->expects($this->once())
+            ->method('setTwoFactorProviderComplete')
+            ->with('totp');
+
+        $this->authenticator->reset();
+        $this->authenticator->createToken($passport, self::FIREWALL_NAME);
+        $this->authenticator->onAuthenticationSuccess($this->request, $token->getAuthenticatedToken(), self::FIREWALL_NAME);
     }
 
     #[Test]

--- a/tests/Security/Http/Authenticator/TwoFactorAuthenticatorTest.php
+++ b/tests/Security/Http/Authenticator/TwoFactorAuthenticatorTest.php
@@ -30,10 +30,8 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Badge\CsrfTokenBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\RememberMeBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
-use function array_values;
 use function assert;
 use function method_exists;
-use function reset;
 
 class TwoFactorAuthenticatorTest extends TestCase
 {
@@ -201,33 +199,6 @@ class TwoFactorAuthenticatorTest extends TestCase
             ->expects($this->atLeastOnce())
             ->method('setAttribute')
             ->with(TwoFactorAuthenticator::FLAG_2FA_COMPLETE, true);
-    }
-
-    /** @param string[] $providerNames */
-    private function stubTwoFactorTokenProviders(MockObject&TwoFactorTokenInterface $twoFactorToken, array $providerNames): void
-    {
-        $twoFactorToken
-            ->expects($this->any())
-            ->method('getTwoFactorProviders')
-            ->willReturnCallback(static function () use (&$providerNames) {
-                return array_values($providerNames);
-            });
-        $twoFactorToken
-            ->method('getCurrentTwoFactorProvider')
-            ->willReturnCallback(static function () use (&$providerNames): string|null {
-                return empty($providerNames) ? null : reset($providerNames);
-            });
-        $twoFactorToken
-            ->method('setTwoFactorProviderComplete')
-            ->willReturnCallback(static function (string $provider) use (&$providerNames): void {
-                foreach ($providerNames as $i => $providerName) {
-                    if ($providerName !== $provider) {
-                        continue;
-                    }
-
-                    unset($providerNames[$i]);
-                }
-            });
     }
 
     #[Test]
@@ -404,12 +375,7 @@ class TwoFactorAuthenticatorTest extends TestCase
             [$this->isInstanceOf(TwoFactorAuthenticationEvent::class), TwoFactorAuthenticationEvents::REQUIRE],
         ]);
 
-        $passport = $this->createPassportWithTwoFactorCredentials($token = $this->createTwoFactorToken());
-        $this->stubTwoFactorTokenProviders($token, ['totp', 'email']);
-
-        $this->authenticator->reset();
-        $this->authenticator->createToken($passport, self::FIREWALL_NAME);
-        $this->authenticator->onAuthenticationSuccess($this->request, $token, self::FIREWALL_NAME);
+        $this->authenticator->onAuthenticationSuccess($this->request, $this->createTwoFactorToken(), self::FIREWALL_NAME);
     }
 
     #[Test]
@@ -429,6 +395,22 @@ class TwoFactorAuthenticatorTest extends TestCase
     }
 
     #[Test]
+    public function onAuthenticationSuccess_authenticationIncomplete_completeProviderOnTwoFactorToken(): void
+    {
+        $twoFactorToken = $this->createTwoFactorToken();
+        $twoFactorToken
+            ->expects($this->any())
+            ->method('getCurrentTwoFactorProvider')
+            ->willReturn('totp');
+        $twoFactorToken
+            ->expects($this->once())
+            ->method('setTwoFactorProviderComplete')
+            ->with('totp');
+
+        $this->authenticator->onAuthenticationSuccess($this->request, $twoFactorToken, self::FIREWALL_NAME);
+    }
+
+    #[Test]
     public function onAuthenticationSuccess_authenticationComplete_dispatchSuccessAndCompleteEvent(): void
     {
         $this->expectDispatchConsecutiveEvents([
@@ -436,18 +418,7 @@ class TwoFactorAuthenticatorTest extends TestCase
             [$this->isInstanceOf(TwoFactorAuthenticationEvent::class), TwoFactorAuthenticationEvents::COMPLETE],
         ]);
 
-        $passport = $this->createPassportWithTwoFactorCredentials($token = $this->createTwoFactorToken());
-        $token
-            ->method('getCurrentTwoFactorProvider')
-            ->willReturn('totp');
-        $token
-            ->expects($this->once())
-            ->method('setTwoFactorProviderComplete')
-            ->with('totp');
-
-        $this->authenticator->reset();
-        $this->authenticator->createToken($passport, self::FIREWALL_NAME);
-        $this->authenticator->onAuthenticationSuccess($this->request, $token->getAuthenticatedToken(), self::FIREWALL_NAME);
+        $this->authenticator->onAuthenticationSuccess($this->request, $this->createMock(TokenInterface::class), self::FIREWALL_NAME);
     }
 
     #[Test]
@@ -464,6 +435,28 @@ class TwoFactorAuthenticatorTest extends TestCase
 
         $returnValue = $this->authenticator->onAuthenticationSuccess($this->request, $token, self::FIREWALL_NAME);
         $this->assertSame($response, $returnValue);
+    }
+
+    #[Test]
+    public function onAuthenticationSuccess_authenticationComplete_completeProviderOnTwoFactorToken(): void
+    {
+        $authenticatedToken = $this->createMock(TokenInterface::class);
+
+        $twoFactorToken = $this->createTwoFactorToken($authenticatedToken, false);
+        $twoFactorToken
+            ->expects($this->any())
+            ->method('getCurrentTwoFactorProvider')
+            ->willReturn('totp');
+        $twoFactorToken
+            ->expects($this->once())
+            ->method('setTwoFactorProviderComplete')
+            ->with('totp');
+
+        // Authentication started with a TwoFactorToken
+        $originalPassport = $this->createPassportWithTwoFactorCredentials($twoFactorToken);
+        $this->authenticator->createToken($originalPassport, self::FIREWALL_NAME);
+
+        $this->authenticator->onAuthenticationSuccess($this->request, $authenticatedToken, self::FIREWALL_NAME);
     }
 
     #[Test]


### PR DESCRIPTION
### Description

Symfony’s standard authentication includes several "post-checks" that run immediately after a successful login, most notably `TwoFactorAuthenticator::onAuthenticationSuccess`.

Starting with Symfony 7.x and 2fa-bundle 7.x (and possibly others), these listeners can generate a loop-redirect, as described in #213.

### The Issue

The root cause is that `TwoFactorToken` marks a provider as completed during badge verification. If an error occurs after this stage, the entire login process is left in an inconsistent state for several reasons:

1. There is no "current provider," even if the system is still processing a provider (e.g., TOTP).
2. At this point, the stored providers (i.e., `getTwoFactorProviders`) are empty, so the active token in `TokenStorage` is inconsistent
3. If authentication fails, the current authentication token is  already switched and the previous inconsistent token remains in storage.
4. Subsequent requests then generate a new "prepared providers" list, but no providers are available, triggering the failure loop.

### The Solution

During badge verification, providers **must not** be marked as complete in the `TwoFactorToken`, as this happens too early in the process. This is critical to keep `TwoFactorTokenInterface::getCurrentTwoFactorProvider` stable throughout the request and avoid the loop issue.

Instead, we need to identify another point to mark the `TwoFactorToken` provider as complete—ideally, at the very end of the authentication process.

By examining the `Symfony\Component\Security\Http\Authentication\AuthenticatorManager::executeAuthenticator` class, I see that the `AuthenticationEvents::AUTHENTICATION_SUCCESS` event (where `UserCheckers` and other checks run) is considered part of the standard process, as it is within the try-catch block. Immediately after this event, `$authenticator->onAuthenticationSuccess` is called, making it the right place to mark the flow as completed.

**Therefore, the solution is to mark the current provider for any `TwoFactorToken` that reaches `TwoFactorAuthenticator::onAuthenticationSuccess` as completed—not before.**

### Tests

I ran many tests in my application, which uses both stateful and stateless authenticators, as well as multiple post-authentication locks, and everything seems to work. However, we only have one OTP method, so the code for handling multiple OTP methods and `$this->dispatchTwoFactorAuthenticationEvent(TwoFactorAuthenticationEvents::REQUIRE, $request, $token)` still needs some testing.

### Minor Breaking Changes

I foresee two minor breaking changes:

1. Updating users may experience changes in `TwoFactorTokenInterface::getCurrentTwoFactorProvider`, e.g. from `null` to `totp` (though this is likely a fix rather than an issue, IMO).
2. The `TwoFactorTokenInterface::allTwoFactorProvidersAuthenticated` method will likely never return `true`, since the previous token forgot after `onSuccessfulAuthentication`.

The main struggle with `TwoFactorTokenInterface` is that the `setTwoFactorProviderComplete` method actually removes a provider from the token, which can cause glitches. My patch addresses this by requiring the authenticator to estimate the "on complete" status by comparing `getTwoFactorProviders` and the active providers. 

Regarding point 2, I may update the `TwoFactorToken` inside the authenticator success so that `TwoFactorTokenInterface::allTwoFactorProvidersAuthenticated` is updated for potential external classes still referencing the token and triggering in post-success events, like `TwoFactorAuthenticationEvents::COMPLETE`.

In a future release, `TwoFactorTokenInterface` may need a cleanup or an improvements to avoid this edge cases.