### PR TITLE
docs(installation): add missing link to step 3 in toc

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -64,7 +64,7 @@ Enable this bundle in your ``config/bundles.php``:
    ];
 
 Step 3: Define routes
-^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~
 
 .. note::
 


### PR DESCRIPTION
**Description**

Add missing link to install step 3 in table of contents.

<img width="393" height="613" alt="image" src="https://github.com/user-attachments/assets/60f87294-1350-40fb-862a-1e5b92265fd4" />


